### PR TITLE
fix flickering of the book listing if a queue is used

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/playback/utils/ChangeNotifier.kt
+++ b/app/src/main/java/de/ph1b/audiobook/playback/utils/ChangeNotifier.kt
@@ -91,8 +91,7 @@ class ChangeNotifier @Inject constructor(
         .setState(playState.playbackStateCompat, position.toLong(), book.playbackSpeed)
         .setActiveQueueItemId(book.chapters.indexOf(book.currentChapter()).toLong())
         .build()
-
-//    appendQueue(book)
+    
     mediaSession.setPlaybackState(playbackState)
 
     if (what == Type.METADATA && lastFileForMetaData != book.currentFile) {

--- a/app/src/main/java/de/ph1b/audiobook/playback/utils/ChangeNotifier.kt
+++ b/app/src/main/java/de/ph1b/audiobook/playback/utils/ChangeNotifier.kt
@@ -92,10 +92,11 @@ class ChangeNotifier @Inject constructor(
         .setActiveQueueItemId(book.chapters.indexOf(book.currentChapter()).toLong())
         .build()
 
-    appendQueue(book)
+//    appendQueue(book)
     mediaSession.setPlaybackState(playbackState)
 
     if (what == Type.METADATA && lastFileForMetaData != book.currentFile) {
+      appendQueue(book)
       // this check is necessary. Else the lockscreen controls will flicker due to
       // an updated picture
       var bitmap: Bitmap? = null


### PR DESCRIPTION
Flickering is fixed. Please include this into your release to make the queue work well.