### PR TITLE
Continue playing when editing current book.

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/playback/MediaPlayer.kt
+++ b/app/src/main/java/de/ph1b/audiobook/playback/MediaPlayer.kt
@@ -135,7 +135,6 @@ constructor(
     if (player.playbackState == Player.STATE_IDLE || bookSubject.value != book) {
       Timber.i("init called with ${book.name}")
       bookSubject.onNext(book)
-      player.playWhenReady = false
       player.prepare(dataSourceConverter.toMediaSource(book))
       player.seekTo(book.currentChapterIndex, book.positionInChapter.toLong())
       player.setPlaybackSpeed(book.playbackSpeed)


### PR DESCRIPTION
* Setting player.playWhenReady = false when editing current playing
  book causes audio to stop and the player shows a pause button that
  does not change state when pushed.
* Besides breaking playback controls, I see no reason to stop playback when a book is edited.
* Fixes #706.