### PR TITLE
Bump Android Gradle plugin to 3.2.0 stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   ]
 
   ext.versions = [
-      androidPlugin      : "3.2.0-rc03",
+      androidPlugin      : "3.2.0",
       conductor          : "2.1.5",
       dagger             : "2.17",
       exoPlayer          : "2.8.4",


### PR DESCRIPTION
Android Studio 3.2 is now stable so we no longer need to use a release
candidate version.