### PR TITLE
Don't set a signing config on debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 
   buildTypes {
     getByName("release") {
+      signingConfig = signingConfigs.getByName("release")
       isMinifyEnabled = true
       isShrinkResources = true
       multiDexEnabled = false
@@ -57,7 +58,6 @@ android {
       multiDexEnabled = true
     }
     all {
-      signingConfig = signingConfigs.getByName("release")
       setProguardFiles(listOf(getDefaultProguardFile("proguard-android.txt"), "proguard.pro"))
     }
   }


### PR DESCRIPTION
This commit updates the app module's gradle script so that the signing
config property is only set on release variants. This meanst thats if
you don't have any real signing keys configured with a
`signing.properties` file you can still build and install a debug
version of the app.

@PaulWoitaschek I doubt you ran into this issue since I assume you set up your signing keys once and forgot about it. This fix allows me to build the app on my machine.