### PR TITLE
Remove custom mockito mocking function

### DIFF
--- a/app/src/test/java/de/ph1b/audiobook/features/bookPlaying/BookPlayPresenterTest.kt
+++ b/app/src/test/java/de/ph1b/audiobook/features/bookPlaying/BookPlayPresenterTest.kt
@@ -6,11 +6,11 @@ import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 import de.ph1b.audiobook.BookFactory
 import de.ph1b.audiobook.common.Optional
 import de.ph1b.audiobook.data.Book
 import de.ph1b.audiobook.data.repo.BookRepository
-import de.ph1b.audiobook.given
 import de.ph1b.audiobook.injection.App
 import de.ph1b.audiobook.playback.PlayStateManager
 import de.ph1b.audiobook.playback.PlayStateManager.PlayState.PAUSED
@@ -43,15 +43,15 @@ class BookPlayPresenterTest {
       sleepTimer = mockSleepTimer
     }
 
-    given { mockBookRepository.booksStream() }.thenReturn(Observable.empty())
-    given { mockBookRepository.byId(any()) }.thenReturn(Observable.just(Optional.Absent()))
-    given { mockPlayStateManager.playStateStream() }.thenReturn(Observable.empty())
-    given { mockSleepTimer.leftSleepTimeInMs }.thenReturn(Observable.empty())
+    whenever(mockBookRepository.booksStream()).thenReturn(Observable.empty())
+    whenever(mockBookRepository.byId(any())).thenReturn(Observable.just(Optional.Absent()))
+    whenever(mockPlayStateManager.playStateStream()).thenReturn(Observable.empty())
+    whenever(mockSleepTimer.leftSleepTimeInMs).thenReturn(Observable.empty())
   }
 
   @Test
   fun sleepTimberShowsTime() {
-    given { mockSleepTimer.leftSleepTimeInMs }.thenReturn(Observable.just(3, 2, 1))
+    whenever(mockSleepTimer.leftSleepTimeInMs).thenReturn(Observable.just(3, 2, 1))
     bookPlayPresenter.attach(mockView)
 
     inOrder(mockView).apply {
@@ -64,7 +64,7 @@ class BookPlayPresenterTest {
   @Test
   fun sleepTimberStopsAfterDetach() {
     val sleepSand = PublishSubject.create<Int>()
-    given { mockSleepTimer.leftSleepTimeInMs }.thenReturn(sleepSand)
+    whenever(mockSleepTimer.leftSleepTimeInMs).thenReturn(sleepSand)
     bookPlayPresenter.attach(mockView)
     bookPlayPresenter.detach()
     sleepSand.onNext(1)
@@ -73,7 +73,7 @@ class BookPlayPresenterTest {
 
   @Test
   fun playState() {
-    given { mockPlayStateManager.playStateStream() }.thenReturn(
+    whenever(mockPlayStateManager.playStateStream()).thenReturn(
       Observable.just(
         PLAYING,
         STOPPED,
@@ -95,7 +95,7 @@ class BookPlayPresenterTest {
   @Test
   fun playStateStopsAfterDetach() {
     val playStateStream = PublishSubject.create<PlayStateManager.PlayState>()
-    given { mockPlayStateManager.playStateStream() }.thenReturn(playStateStream)
+    whenever(mockPlayStateManager.playStateStream()).thenReturn(playStateStream)
     bookPlayPresenter.attach(mockView)
     bookPlayPresenter.detach()
     verify(mockView, never()).showLeftSleepTime(any())
@@ -104,7 +104,7 @@ class BookPlayPresenterTest {
   @Test
   fun bookStreamStopsAfterDetach() {
     val bookStream = PublishSubject.create<List<Book>>()
-    given { mockBookRepository.booksStream() }.thenReturn(bookStream)
+    whenever(mockBookRepository.booksStream()).thenReturn(bookStream)
     bookPlayPresenter.attach(mockView)
     bookPlayPresenter.detach()
     val bookWithCorrectId = BookFactory.create(id = bookId, time = 0)
@@ -166,11 +166,11 @@ class BookPlayPresenterTest {
   }
 
   private fun bookRepoWillReturn(book: Book) {
-    given { mockBookRepository.byId(bookId) }.doAnswer { invocation ->
+    whenever(mockBookRepository.byId(bookId)).doAnswer { invocation ->
       val id = invocation.getArgument<UUID>(0)
       Observable.just(Optional.of(book.takeIf { id == book.id }))
     }
-    given { mockBookRepository.bookById(bookId) }.doAnswer { invocation ->
+    whenever(mockBookRepository.bookById(bookId)).doAnswer { invocation ->
       val id = invocation.getArgument<UUID>(0)
       book.takeIf { book.id == id }
     }
@@ -179,7 +179,7 @@ class BookPlayPresenterTest {
   @Test
   fun seeToWithFile() {
     val book = BookFactory.create(id = bookId)
-    given { mockBookRepository.bookById(bookId) }.thenReturn(book)
+    whenever(mockBookRepository.bookById(bookId)).thenReturn(book)
     bookPlayPresenter.attach(mockView)
     val lastFile = book.content.chapters.last().file
     bookPlayPresenter.seekTo(100, lastFile)
@@ -188,7 +188,7 @@ class BookPlayPresenterTest {
 
   @Test
   fun toggleActiveSleepTimberCancels() {
-    given { mockSleepTimer.sleepTimerActive() }.thenReturn(true)
+    whenever(mockSleepTimer.sleepTimerActive()).thenReturn(true)
     bookPlayPresenter.attach(mockView)
     bookPlayPresenter.toggleSleepTimer()
     verify(mockSleepTimer).setActive(false)
@@ -197,7 +197,7 @@ class BookPlayPresenterTest {
 
   @Test
   fun toggleSleepTimberInInactiveStateOpensMenu() {
-    given { mockSleepTimer.sleepTimerActive() }.thenReturn(false)
+    whenever(mockSleepTimer.sleepTimerActive()).thenReturn(false)
     bookPlayPresenter.attach(mockView)
     bookPlayPresenter.toggleSleepTimer()
     verify(mockSleepTimer, never()).setActive(any())

--- a/app/src/test/java/de/ph1b/audiobook/features/bookSearch/BookSearchHandlerTest.kt
+++ b/app/src/test/java/de/ph1b/audiobook/features/bookSearch/BookSearchHandlerTest.kt
@@ -3,6 +3,7 @@ package de.ph1b.audiobook.features.bookSearch
 import android.annotation.SuppressLint
 import android.provider.MediaStore
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.whenever
 import de.ph1b.audiobook.MemoryPref
 import de.ph1b.audiobook.common.sparseArray.emptySparseArray
 import de.ph1b.audiobook.data.Book
@@ -11,7 +12,6 @@ import de.ph1b.audiobook.data.BookMetaData
 import de.ph1b.audiobook.data.BookSettings
 import de.ph1b.audiobook.data.Chapter
 import de.ph1b.audiobook.data.repo.BookRepository
-import de.ph1b.audiobook.given
 import de.ph1b.audiobook.persistence.pref.Pref
 import de.ph1b.audiobook.playback.PlayerController
 import org.junit.Before
@@ -137,7 +137,7 @@ class BookSearchHandlerTest {
   fun setUp() {
     MockitoAnnotations.initMocks(this)
 
-    given { repo.activeBooks }.thenReturn(listOf(anotherBook, bookToFind))
+    whenever(repo.activeBooks).thenReturn(listOf(anotherBook, bookToFind))
     currentBookIdPref = MemoryPref(UUID.randomUUID())
 
     searchHandler = BookSearchHandler(repo, player, currentBookIdPref)
@@ -199,7 +199,7 @@ class BookSearchHandlerTest {
   @Test
   fun mediaFocusArtistInTitleNoArtistInBook() {
     val bookToFind = bookToFind.updateMetaData { copy(author = null, name = "The book of Tim") }
-    given { repo.activeBooks }.thenReturn(listOf(bookToFind))
+    whenever(repo.activeBooks).thenReturn(listOf(bookToFind))
 
     val bookSearch = BookSearch(
       mediaFocus = MediaStore.Audio.Artists.ENTRY_CONTENT_TYPE,

--- a/app/src/test/java/de/ph1b/audiobook/mockito.kt
+++ b/app/src/test/java/de/ph1b/audiobook/mockito.kt
@@ -1,6 +1,0 @@
-package de.ph1b.audiobook
-
-import org.mockito.Mockito
-import org.mockito.stubbing.OngoingStubbing
-
-fun <T> given(methodCall: () -> T): OngoingStubbing<T> = Mockito.`when`(methodCall())


### PR DESCRIPTION
The project already uses the extension library `mockito-kotlin` which
provides helper functions to make Mockito work with Kotlin. There is no
need for our custom `given` function if we can use the built in
`whenever`. This also makes it less confusing to new developers.