### PR TITLE
README.md licence link missing the (L) in (L)GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Or you can start translating a new language if you speak it ;-)
 # License
 Copyright (C) 2014 [Paul Woitaschek](http://www.paul-woitaschek.de/)
 
-The license is [GnuGPLv3](https://github.com/PaulWoitaschek/Voice/blob/master/LICENSE.md). With contributing you agree to license your code under the same conditions.
+The license is [Gnu LGPLv3](https://github.com/PaulWoitaschek/Voice/blob/master/LICENSE.md). With contributing you agree to license your code under the same conditions.


### PR DESCRIPTION
In noticed when required to translate a string with "GPLv3" on the Transifex portal. 
In facts, might require updating the string "Open Source license is Gnu GPLv3" in the document "Play Store Description" on Transifex.

Thumbs up for the project.