### PR TITLE
Updated broken translation URL

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/features/settings/dialogs/SupportDialogController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/settings/dialogs/SupportDialogController.kt
@@ -39,6 +39,6 @@ class SupportDialogController : DialogController() {
   companion object {
     private val GITHUB_URL = Uri.parse("https://github.com/Ph1b/MaterialAudiobookPlayer")!!
     private val TRANSLATION_URL =
-      Uri.parse("https://www.transifex.com/projects/p/material-audiobook-player")!!
+      Uri.parse("https://www.transifex.com/projects/p/voice")!!
   }
 }


### PR DESCRIPTION
Since the rename to Voice, clicking the Translations option under the heart in preferences takes you to a nonexistent transifex project ([material-audiobook-player](https://www.transifex.com/projects/p/material-audiobook-player/)). Updated it to the new one.