### PR TITLE
Disable Room queries on the main thread

### DIFF
--- a/data/src/main/java/de/ph1b/audiobook/data/repo/internals/PersistenceModule.kt
+++ b/data/src/main/java/de/ph1b/audiobook/data/repo/internals/PersistenceModule.kt
@@ -46,7 +46,6 @@ class PersistenceModule {
   @Provides
   fun roomDatabaseBuilder(context: Context): RoomDatabase.Builder<AppDb> {
     return Room.databaseBuilder(context, AppDb::class.java, AppDb.DATABASE_NAME)
-      .allowMainThreadQueries()
   }
 
   @Provides


### PR DESCRIPTION
Currently our Room db builder allows queries on the main thread. This
can result in dropped frames and poor performance. With
e4e5b502f69d73c1e3b95b14db908a33c9c5e3c9, `BookStorage` no longer runs
queries on the main thread so we can disable this Room setting.