### PR TITLE
Workaround to prevent burning eyes when starting the app in the dark.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
 
         <activity
             android:name=".features.MainActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:theme="@style/LoadingTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/de/ph1b/audiobook/features/MainActivity.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : BaseActivity(), RouterProvider {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     appComponent.inject(this)
+    setTheme(R.style.AppTheme) // revert the loading theme
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_book)
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,4 +32,6 @@
     <color name="textColorPrimary">@color/abc_primary_text_material_light</color>
     <color name="textColorSecondary">@color/abc_secondary_text_material_light</color>
     <color name="placeholderCoverColor">@color/grey200</color>
+
+    <color name="startupColor">@color/black</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,4 +74,9 @@
         <item name="android:background">?attr/selectableItemBackground</item>
         <item name="android:gravity">center</item>
     </style>
+
+    <style name="LoadingTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowBackground">@color/startupColor</item>
+        <item name="colorPrimaryDark">@color/startupColor</item>
+    </style>
 </resources>


### PR DESCRIPTION
My humble attempt to fix white screen while the app is loading. I'm using the app only in the dark and the white startup screen really hurts eyes.