### PR TITLE
Add setting to allow global save of last playback speed for future playbacks

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsController.kt
@@ -29,6 +29,8 @@ class SettingsController : BaseController() {
   lateinit var autoRewindAmountPref: Pref<Int>
   @field:[Inject Named(PrefKeys.SEEK_TIME)]
   lateinit var seekTimePref: Pref<Int>
+  @field:[Inject Named(PrefKeys.SAVE_PLAYBACK_SPEED)]
+  lateinit var savePlaybackPref: Pref<Boolean>
 
   init {
     appComponent.inject(this)
@@ -81,6 +83,14 @@ class SettingsController : BaseController() {
       .map { resources!!.getQuantityString(R.plurals.seconds, it, it) }
       .subscribe { autoRewind.setDescription(it) }
       .disposeOnDestroyView()
+
+    // save playback speed
+    setupSwitchSetting(
+        settingView = savePlaybackSpeed,
+        titleRes = R.string.pref_save_playback_speed,
+        contentRes = R.string.pref_save_playback_speed_hint,
+        pref = savePlaybackPref
+    )
   }
 
   private fun setupToolbar() {

--- a/app/src/main/java/de/ph1b/audiobook/injection/PrefKeys.kt
+++ b/app/src/main/java/de/ph1b/audiobook/injection/PrefKeys.kt
@@ -13,4 +13,6 @@ object PrefKeys {
   const val CURRENT_BOOK = "currentBook2"
   const val THEME = "THEME2_KEY"
   const val GRID_MODE = "gridView"
+  const val SAVE_PLAYBACK_SPEED = "SAVE_PLAYBACK_SPEED"
+  const val PLAYING_SPEED = "PLAYING_SPEED"
 }

--- a/app/src/main/java/de/ph1b/audiobook/injection/PrefsModule.kt
+++ b/app/src/main/java/de/ph1b/audiobook/injection/PrefsModule.kt
@@ -52,6 +52,24 @@ object PrefsModule {
   @Provides
   @JvmStatic
   @Singleton
+  @Named(PrefKeys.SAVE_PLAYBACK_SPEED)
+  fun provideSavePlaybackPreference(prefs: RxSharedPreferences): Pref<Boolean> {
+    val pref = prefs.getBoolean(PrefKeys.SAVE_PLAYBACK_SPEED, false)
+    return PersistentPref(pref)
+  }
+
+  @Provides
+  @JvmStatic
+  @Singleton
+  @Named(PrefKeys.PLAYING_SPEED)
+  fun providePlayingSpeedPreference(prefs: RxSharedPreferences): Pref<Float> {
+    val pref = prefs.getFloat(PrefKeys.SLEEP_TIME, 1F)
+    return PersistentPref(pref)
+  }
+
+  @Provides
+  @JvmStatic
+  @Singleton
   @Named(PrefKeys.BOOKMARK_ON_SLEEP)
   fun provideBookmarkOnSleepTimerPreference(prefs: RxSharedPreferences): Pref<Boolean> {
     val pref = prefs.getBoolean(PrefKeys.BOOKMARK_ON_SLEEP, false)

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -46,6 +46,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
+            <de.ph1b.audiobook.features.settings.SwitchSettingView
+                android:id="@+id/savePlaybackSpeed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -60,10 +60,14 @@
     <string name="bookmark_edit_hint">Bookmark name</string>
     <string name="bookmark_added">Bookmark added</string>
     <string name="bookmark_delete_title">Delete this bookmark?</string>
+    <!--Files-->
+    <string name="delete_file">Delete</string>
     <!--Settings-->
     <string name="action_settings">Preferences</string>
     <string name="pref_resume_on_replug">Resume playback</string>
     <string name="pref_resume_on_replug_hint">If you paused by plugging headset out, it will resume on replug.</string>
+    <string name="pref_save_playback_speed">Save playback speed</string>
+    <string name="pref_save_playback_speed_hint">If you change playback speed during playback, that setting will be used for future playbacks.</string>
     <string name="min">%s min</string>
     <string name="delete_last_number">Deletes the last entered number</string>
     <plurals name="seconds">


### PR DESCRIPTION
This PR addresses #860 (global playback speed).

Added an item to the settings page to allow the save of playback speed so that all future playback will occur at that speed.  The default setting (false) is to leave the app behavior unchanged.  If changed to "true", then if playback speed is changed during any playback, all future playback will occur at that speed.