### PR TITLE
Removes unnecessary comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Its always a good idea to talk about what are going to do before you actually st
 Some rules for coding:
 * Use the code style the project uses
 * For each feature, make a seperate branch, so it can be reviewed separately
-* Use commits with a good description, so everyone can see, what you did
+* Use commits with a good description, so everyone can see what you did
 
 ## <a name="trans">Translations</a>
 The project page is on [transifex](https://www.transifex.com/PaulWoitaschek/voice/). There all the localizations are maintained. If you want to contribute, check if there are untranslated or wrong translated words.


### PR DESCRIPTION
This PR removes unnecessary comma on Readme:

> Use commits with a good description, so everyone can see, what you did

to 

> Use commits with a good description, so everyone can see what you did