### PR TITLE
KidsMode (or SimpleMode) to reduce the complexity of the App

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/features/bookOverview/BookOverviewController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/bookOverview/BookOverviewController.kt
@@ -56,6 +56,9 @@ class BookOverviewController : ViewBindingController<BookOverviewBinding>(BookOv
   @field:[Inject Named(PrefKeys.CURRENT_BOOK)]
   lateinit var currentBookIdPref: Pref<UUID>
 
+  @field:[Inject Named(PrefKeys.KIDS_MODE)]
+  lateinit var kidsMode: Pref<Boolean>
+
   @Inject
   lateinit var viewModel: BookOverviewViewModel
 
@@ -142,6 +145,7 @@ class BookOverviewController : ViewBindingController<BookOverviewBinding>(BookOv
   }
 
   private fun BookOverviewBinding.gridMenuItem(): GridMenuItem = GridMenuItem(toolbar.menu.findItem(R.id.toggleGrid))
+  private fun BookOverviewBinding.libraryMenuItem(): LibraryMenuItem = LibraryMenuItem(toolbar.menu.findItem(R.id.library))
 
   private fun toFolderOverview() {
     val controller = FolderOverviewController()
@@ -206,7 +210,12 @@ class BookOverviewController : ViewBindingController<BookOverviewBinding>(BookOv
     }
 
     loadingProgress.isVisible = state == BookOverviewState.Loading
-    gridMenuItem.item.isVisible = state != BookOverviewState.Loading
+    if(kidsMode.value) {
+      libraryMenuItem().item.isVisible = false
+      gridMenuItem.item.isVisible = false
+    } else {
+      gridMenuItem.item.isVisible = state != BookOverviewState.Loading
+    }
   }
 
   private fun showPlaying(playing: Boolean) {
@@ -289,3 +298,4 @@ class BookOverviewController : ViewBindingController<BookOverviewBinding>(BookOv
 }
 
 private inline class GridMenuItem(val item: MenuItem)
+private inline class LibraryMenuItem(val item: MenuItem)

--- a/app/src/main/java/de/ph1b/audiobook/features/bookOverview/BookOverviewController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/bookOverview/BookOverviewController.kt
@@ -174,7 +174,9 @@ class BookOverviewController : ViewBindingController<BookOverviewBinding>(BookOv
     val adapterContent = when (state) {
       is BookOverviewState.Content -> buildList {
         state.categoriesWithContents.forEach { (category, content) ->
-          add(BookOverviewHeaderModel(category, content.hasMore))
+          if(!kidsMode.value) {
+            add(BookOverviewHeaderModel(category, content.hasMore))
+          }
           addAll(content.books)
         }
       }

--- a/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayController.kt
@@ -6,6 +6,7 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import androidx.core.view.GestureDetectorCompat
+import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import com.google.android.material.slider.Slider
 import com.google.android.material.snackbar.Snackbar
@@ -26,12 +27,15 @@ import de.ph1b.audiobook.misc.formatTime
 import de.ph1b.audiobook.misc.getUUID
 import de.ph1b.audiobook.misc.putUUID
 import de.ph1b.audiobook.playback.player.Equalizer
+import de.paulwoitaschek.flowpref.Pref
+import de.ph1b.audiobook.common.pref.PrefKeys
 import de.ph1b.audiobook.uitools.PlayPauseDrawableSetter
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.time.Duration
 
 private const val NI_BOOK_ID = "niBookId"
@@ -47,6 +51,9 @@ class BookPlayController(bundle: Bundle) : ViewBindingController<BookPlayBinding
   lateinit var equalizer: Equalizer
   @Inject
   lateinit var viewModel: BookPlayViewModel
+
+  @field:[Inject Named(PrefKeys.KIDS_MODE)]
+  lateinit var kidsMode: Pref<Boolean>
 
   private val bookId = bundle.getUUID(NI_BOOK_ID)
   private var coverLoaded = false
@@ -228,6 +235,10 @@ class BookPlayController(bundle: Bundle) : ViewBindingController<BookPlayBinding
         }
         else -> false
       }
+    }
+    // hide all menu items in kids mode
+    if(kidsMode.value) {
+      binding.toolbar.menu.forEach { item: MenuItem -> item.isVisible = false }
     }
   }
 

--- a/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayController.kt
@@ -108,6 +108,7 @@ class BookPlayController(bundle: Bundle) : ViewBindingController<BookPlayBinding
   private fun BookPlayBinding.render(viewState: BookPlayViewState) {
     Timber.d("render $viewState")
     toolbar.title = viewState.title
+    currentChapterText.textSize = if(kidsMode.value) 20.0f else 12.0f
     currentChapterText.text = viewState.chapterName
     currentChapterContainer.isVisible = viewState.chapterName != null
     previous.isVisible = viewState.showPreviousNextButtons
@@ -194,7 +195,7 @@ class BookPlayController(bundle: Bundle) : ViewBindingController<BookPlayBinding
         this.viewModel.addBookmark()
         true
       }
-
+      
     binding.toolbar.setNavigationOnClickListener { router.popController(this) }
     binding.toolbar.setOnMenuItemClickListener {
       when (it.itemId) {

--- a/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayViewModel.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/bookPlaying/BookPlayViewModel.kt
@@ -29,6 +29,8 @@ class BookPlayViewModel
   private val sleepTimer: SleepTimer,
   private val playStateManager: PlayStateManager,
   private val bookmarkRepo: BookmarkRepo,
+  @Named(PrefKeys.KIDS_MODE)
+  private val kidsMode: Pref<Boolean>,
   @Named(PrefKeys.CURRENT_BOOK)
   private val currentBookIdPref: Pref<UUID>
 ) {
@@ -48,12 +50,13 @@ class BookPlayViewModel
     ) { book, playState, sleepTime ->
       val currentMark = book.content.currentChapter.markForPosition(book.content.positionInChapter)
       val hasMoreThanOneChapter = book.hasMoreThanOneChapter()
+      val chapterNumber = book.content.currentChapterIndex.toString() + " / " + book.content.chapters.size
       BookPlayViewState(
         sleepTime = sleepTime,
         playing = playState == PlayStateManager.PlayState.Playing,
         title = book.name,
         showPreviousNextButtons = hasMoreThanOneChapter,
-        chapterName = currentMark.name.takeIf { hasMoreThanOneChapter },
+        chapterName =  if(kidsMode.value) chapterNumber else currentMark.name.takeIf { hasMoreThanOneChapter },
         duration = currentMark.durationMs.milliseconds,
         playedTime = (book.content.positionInChapter - currentMark.startMs).milliseconds,
         cover = BookPlayCover(book),

--- a/app/src/main/java/de/ph1b/audiobook/features/gridCount/GridCount.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/gridCount/GridCount.kt
@@ -1,20 +1,26 @@
 package de.ph1b.audiobook.features.gridCount
 
 import android.content.Context
+import de.paulwoitaschek.flowpref.Pref
+import de.ph1b.audiobook.common.pref.PrefKeys
 import de.ph1b.audiobook.features.bookOverview.GridMode
 import de.ph1b.audiobook.features.bookOverview.GridMode.FOLLOW_DEVICE
 import de.ph1b.audiobook.features.bookOverview.GridMode.GRID
 import de.ph1b.audiobook.features.bookOverview.GridMode.LIST
 import de.ph1b.audiobook.misc.dpToPx
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.math.roundToInt
 
 class GridCount
 @Inject constructor(
-  private val context: Context
+  private val context: Context,
+  @Named(PrefKeys.KIDS_MODE)
+  private val kidsMode: Pref<Boolean>
 ) {
 
   fun gridColumnCount(mode: GridMode): Int {
+    if(kidsMode.value) return gridColumnCount()
     val useGrid = when (mode) {
       LIST -> false
       GRID -> true

--- a/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsController.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsController.kt
@@ -27,6 +27,7 @@ class SettingsController : ViewBindingController<SettingsBinding>(SettingsBindin
 
     resumePlayback.onCheckedChanged { viewModel.toggleResumeOnReplug() }
     darkTheme.onCheckedChanged { viewModel.toggleDarkTheme() }
+    kidsMode.onCheckedChanged { viewModel.toggleKidsMode() }
 
     skipAmount.setOnClickListener {
       viewModel.changeSkipAmount()
@@ -63,6 +64,7 @@ class SettingsController : ViewBindingController<SettingsBinding>(SettingsBindin
 
   private fun SettingsBinding.render(state: SettingsViewState) {
     Timber.d("render $state")
+    kidsMode.setChecked(state.kidsMode);
     darkTheme.isVisible = state.showDarkThemePref
     darkTheme.setChecked(state.useDarkTheme)
     resumePlayback.setChecked(state.resumeOnReplug)

--- a/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsViewModel.kt
@@ -19,7 +19,9 @@ class SettingsViewModel
   @Named(PrefKeys.AUTO_REWIND_AMOUNT)
   private val autoRewindAmountPref: Pref<Int>,
   @Named(PrefKeys.SEEK_TIME)
-  private val seekTimePref: Pref<Int>
+  private val seekTimePref: Pref<Int>,
+  @Named(PrefKeys.KIDS_MODE)
+  private val kidsMode: Pref<Boolean>
 ) {
 
   private val _viewEffects = BroadcastChannel<SettingsViewEffect>(1)
@@ -30,14 +32,16 @@ class SettingsViewModel
       useDarkTheme.flow,
       resumeOnReplugPref.flow,
       autoRewindAmountPref.flow,
-      seekTimePref.flow
-    ) { useDarkTheme, resumeOnreplug, autoRewindAmount, seekTime ->
+      seekTimePref.flow,
+      kidsMode.flow
+    ) { useDarkTheme, resumeOnreplug, autoRewindAmount, seekTime, kidsMode ->
       SettingsViewState(
         useDarkTheme = useDarkTheme,
         showDarkThemePref = DARK_THEME_SETTABLE,
         resumeOnReplug = resumeOnreplug,
         seekTimeInSeconds = seekTime,
-        autoRewindInSeconds = autoRewindAmount
+        autoRewindInSeconds = autoRewindAmount,
+        kidsMode = kidsMode
       )
     }
   }
@@ -56,5 +60,9 @@ class SettingsViewModel
 
   fun changeAutoRewindAmount() {
     _viewEffects.offer(SettingsViewEffect.ShowChangeAutoRewindAmountDialog(seekTimePref.value))
+  }
+
+  fun toggleKidsMode() {
+    kidsMode.value = !kidsMode.value
   }
 }

--- a/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsViewState.kt
+++ b/app/src/main/java/de/ph1b/audiobook/features/settings/SettingsViewState.kt
@@ -5,5 +5,6 @@ data class SettingsViewState(
   val showDarkThemePref: Boolean,
   val resumeOnReplug: Boolean,
   val seekTimeInSeconds: Int,
-  val autoRewindInSeconds: Int
+  val autoRewindInSeconds: Int,
+  val kidsMode: Boolean
 )

--- a/app/src/main/java/de/ph1b/audiobook/injection/PrefsModule.kt
+++ b/app/src/main/java/de/ph1b/audiobook/injection/PrefsModule.kt
@@ -45,6 +45,14 @@ object PrefsModule {
   @Provides
   @JvmStatic
   @Singleton
+  @Named(PrefKeys.KIDS_MODE)
+  fun kidsModePref(prefs: AndroidPreferences): Pref<Boolean> {
+    return prefs.boolean(PrefKeys.KIDS_MODE, false)
+  }
+
+  @Provides
+  @JvmStatic
+  @Singleton
   @Named(PrefKeys.RESUME_ON_REPLUG)
   fun provideResumeOnReplugPreference(prefs: AndroidPreferences): Pref<Boolean> {
     return prefs.boolean(PrefKeys.RESUME_ON_REPLUG, true)

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -32,6 +32,13 @@
               app:ssv_title="@string/pref_theme_dark" />
 
             <de.ph1b.audiobook.features.settings.SwitchSettingView
+              android:id="@+id/kidsMode"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              app:ssv_title="@string/pref_kids_mode"
+              app:ssv_description="@string/pref_kids_mode_description" />
+
+            <de.ph1b.audiobook.features.settings.SwitchSettingView
               android:id="@+id/resumePlayback"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"

--- a/common/src/main/java/de/ph1b/audiobook/common/pref/PrefKeys.kt
+++ b/common/src/main/java/de/ph1b/audiobook/common/pref/PrefKeys.kt
@@ -10,5 +10,6 @@ object PrefKeys {
   const val COLLECTION_BOOK_FOLDERS = "folders"
   const val CURRENT_BOOK = "currentBook2"
   const val DARK_THEME = "darkTheme"
+  const val KIDS_MODE = "kidsMode"
   const val GRID_MODE = "gridView"
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="pref_seek_time">Skip amount</string>
     <string name="pref_root_folder_title">Audiobook folder</string>
     <string name="pref_theme_dark">Dark Theme</string>
+    <string name="pref_kids_mode">Kids Mode</string>
+    <string name="pref_kids_mode_description">Kids Mode reduces text, controls and always shows all audiobooks</string>
     <string name="pref_auto_rewind_title">Auto rewind</string>
     <plurals name="pref_auto_rewind_summary">
         <item quantity="one">Automatically rewinds %d second after manual pausing.</item>


### PR DESCRIPTION
I like this app for playing audiobooks. But now the kids also want to use it, but they cannot read yet and dont need so much functionalities, so i decided to create this KidsMode PR. It also addresses #984 but only partially. 

The Pull Request contains the following commits:
- A setting to enable/disable KidsMode in the settings. Only when the setting is enabled all the following happens.
- Hiding Library- and Grid-Button in the overview. The listview is not very useful if your kids cant read yet, and they do not need to add new audiobooks.
- Disable the categories only showing the CURRENT category, but with all audiobooks (This setting will not be useful if you have a lot of audiobooks)
- Hide the Toolbar Buttons during play, they dont need all the settings
- The currently playing chapter is shown as x / y which is easier for the Kids to recognize then the mp3 titles.

Points to improve:
- Disabling the categories could be cleaner, but i did not find a better place to do it, maybe someone has a hint?
- Maybe separate the KidsMode setting in to multiple settings, for example the sleep timer could be usefull for kids, or someone still wants the categories.
- Rework the Play-Layout for KidsMode, without the position slider, but bigger chapter buttons, or volume controls?
- Dont call it KidsMode, call it SimpleMode or call it ...?
