### PR TITLE
Restore fade out code

### DIFF
--- a/app/src/main/java/de/ph1b/audiobook/playback/SleepTimer.kt
+++ b/app/src/main/java/de/ph1b/audiobook/playback/SleepTimer.kt
@@ -2,6 +2,7 @@ package de.ph1b.audiobook.playback
 
 import de.paulwoitaschek.flowpref.Pref
 import de.ph1b.audiobook.common.pref.PrefKeys
+import de.ph1b.audiobook.playback.player.FADE_OUT_DURATION
 import de.ph1b.audiobook.playback.playstate.PlayStateManager
 import de.ph1b.audiobook.playback.playstate.PlayStateManager.PlayState.Playing
 import kotlinx.coroutines.Job
@@ -77,12 +78,16 @@ class SleepTimer
 
   private suspend fun startSleepTimerCountdown() {
     val interval = 500.milliseconds
+    var fadeOutSent = false
     while (leftSleepTime > Duration.ZERO) {
       suspendUntilPlaying()
       delay(interval)
       leftSleepTime = (leftSleepTime - interval).coerceAtLeast(Duration.ZERO)
+      if (leftSleepTime <= FADE_OUT_DURATION && !fadeOutSent) {
+        fadeOutSent = true
+        playerController.fadeOut()
+      }
     }
-    playerController.pause()
   }
 
   private suspend fun suspendUntilPlaying() {
@@ -98,5 +103,6 @@ class SleepTimer
   private fun cancel() {
     sleepJob?.cancel()
     leftSleepTime = Duration.ZERO
+    playerController.cancelFadeout()
   }
 }

--- a/playback/src/main/java/de/ph1b/audiobook/playback/PlayerController.kt
+++ b/playback/src/main/java/de/ph1b/audiobook/playback/PlayerController.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.session.MediaControllerCompat
 import de.ph1b.audiobook.playback.session.PlaybackService
+import de.ph1b.audiobook.playback.session.cancelFadeOut
+import de.ph1b.audiobook.playback.session.fadeOut
 import de.ph1b.audiobook.playback.session.forcedNext
 import de.ph1b.audiobook.playback.session.forcedPrevious
 import de.ph1b.audiobook.playback.session.playPause
@@ -74,6 +76,10 @@ class PlayerController
   fun pause() = execute { it.pause() }
 
   fun setSpeed(speed: Float) = execute { it.setPlaybackSpeed(speed) }
+
+  fun fadeOut() = execute { it.fadeOut() }
+
+  fun cancelFadeout() = execute { it.cancelFadeOut() }
 
   private inline fun execute(action: (MediaControllerCompat.TransportControls) -> Unit) {
     _controller?.transportControls?.let(action)

--- a/playback/src/main/java/de/ph1b/audiobook/playback/player/MediaPlayer.kt
+++ b/playback/src/main/java/de/ph1b/audiobook/playback/player/MediaPlayer.kt
@@ -1,6 +1,7 @@
 package de.ph1b.audiobook.playback.player
 
 import android.support.v4.media.session.PlaybackStateCompat
+import android.view.animation.AccelerateInterpolator
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
@@ -18,6 +19,7 @@ import de.ph1b.audiobook.playback.playstate.PlayStateManager
 import de.ph1b.audiobook.playback.playstate.PlayStateManager.PlayState
 import de.ph1b.audiobook.playback.playstate.PlayerState
 import de.ph1b.audiobook.playback.session.ChangeNotifier
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
@@ -42,6 +44,8 @@ import javax.inject.Named
 import kotlin.time.Duration
 import kotlin.time.milliseconds
 import kotlin.time.seconds
+
+val FADE_OUT_DURATION = 10.seconds
 
 @PerService
 class MediaPlayer
@@ -418,11 +422,46 @@ constructor(
     }
   }
 
+  private var fadeOutJob: Job? = null
+
+  fun fadeOut() {
+    if (fadeOutJob?.isActive == true) {
+      return
+    }
+    fadeOutJob = scope.launch {
+      var timeLeft = FADE_OUT_DURATION
+      val step = 100.milliseconds
+      while (timeLeft > Duration.ZERO) {
+        delay(step)
+        timeLeft -= step
+        player.volume = volumeForFadeOutTimeLeft(timeLeft)
+      }
+      pause(rewind = false)
+      skip(-FADE_OUT_DURATION)
+      player.volume = 1F
+      player.stop()
+    }
+  }
+
+  fun cancelFadeOut() {
+    fadeOutJob?.cancel()
+    player.volume = 1F
+    play()
+  }
+
   fun release() {
     player.release()
     scope.cancel()
   }
 }
+
+private fun volumeForFadeOutTimeLeft(timeLeft: Duration): Float {
+  val fraction = (timeLeft / FADE_OUT_DURATION).toFloat()
+  return FADE_OUT_INTERPOLATOR.getInterpolation(fraction)
+    .also { Timber.i("set volume to $it") }
+}
+
+private val FADE_OUT_INTERPOLATOR = AccelerateInterpolator()
 
 private fun Chapter.nextMark(positionInChapterMs: Long): ChapterMark? {
   val markForPosition = markForPosition(positionInChapterMs)

--- a/playback/src/main/java/de/ph1b/audiobook/playback/session/MediaSessionCallback.kt
+++ b/playback/src/main/java/de/ph1b/audiobook/playback/session/MediaSessionCallback.kt
@@ -130,6 +130,12 @@ class MediaSessionCallback
         val time = extras.getLong(SET_POSITION_EXTRA_TIME)
         player.changePosition(time, file)
       }
+      FADE_OUT_ACTION -> {
+        player.fadeOut()
+      }
+      CANCEL_FADE_OUT_ACTION -> {
+        player.cancelFadeOut()
+      }
       FORCED_PREVIOUS -> {
         player.previous(toNullOfNewTrack = true)
       }
@@ -173,6 +179,14 @@ fun TransportControls.setPosition(time: Long, file: File) = sendCustomAction(SET
   putString(SET_POSITION_EXTRA_FILE, file.absolutePath)
   putLong(SET_POSITION_EXTRA_TIME, time)
 }
+
+private const val FADE_OUT_ACTION = "fadeOut"
+
+fun TransportControls.fadeOut() = sendCustomAction(FADE_OUT_ACTION)
+
+private const val CANCEL_FADE_OUT_ACTION = "cancelFadeOut"
+
+fun TransportControls.cancelFadeOut() = sendCustomAction(CANCEL_FADE_OUT_ACTION)
 
 const val ANDROID_AUTO_ACTION_FAST_FORWARD = "fast_forward"
 const val ANDROID_AUTO_ACTION_REWIND = "rewind"


### PR DESCRIPTION
This commit restores the fade function and does not remove the shakeToResetTime code.
I just reverted the lines and did not add any new code. I haven't worked with Android yet, but after restoring those lines, the fade works again. I ran the app in the emulator and tested the behavior. I have also run all the tests. However, I'm not sure if that's all that can be tested, so it could be that I missed a testing opportunity.

Also, I couldn't find a reason in the commit message for removing the fade. If there is one, please let me know.
