### PR TITLE
Adding 'Mark as Current', 'Mark as Not Started Yet', 'Mark as Complete'. Fixes #1046

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/EditBookBottomSheetState.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/EditBookBottomSheetState.kt
@@ -2,8 +2,11 @@ package voice.bookOverview.bottomSheet
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Done
 import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.NotStarted
 import androidx.compose.material.icons.outlined.Title
 import androidx.compose.ui.graphics.vector.ImageVector
 import voice.bookOverview.R
@@ -19,4 +22,7 @@ enum class BottomSheetItem(
   Title(R.string.change_book_name, Icons.Outlined.Title),
   InternetCover(R.string.download_book_cover, Icons.Outlined.Download),
   FileCover(R.string.pick_book_cover, Icons.Outlined.Image),
+  BookCategoryMarkAsNotStarted(R.string.mark_as_not_started, Icons.Outlined.HourglassEmpty),
+  BookCategoryMarkAsCurrent(R.string.mark_as_current, Icons.Outlined.NotStarted),
+  BookCategoryMarkAsCompleted(R.string.mark_as_completed, Icons.Outlined.Done),
 }

--- a/bookOverview/src/main/kotlin/voice/bookOverview/di/BookOverviewComponent.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/di/BookOverviewComponent.kt
@@ -4,6 +4,7 @@ import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.BindsInstance
 import voice.bookOverview.bottomSheet.BottomSheetViewModel
+import voice.bookOverview.editBookCategory.EditBookCategoryViewModel
 import voice.bookOverview.editTitle.EditBookTitleViewModel
 import voice.bookOverview.overview.BookOverviewNavigator
 import voice.bookOverview.overview.BookOverviewViewModel
@@ -18,6 +19,7 @@ annotation class BookOverviewScope
 interface BookOverviewComponent {
   val bookOverviewViewModel: BookOverviewViewModel
   val editBookTitleViewModel: EditBookTitleViewModel
+  val editBookCategoryViewModel: EditBookCategoryViewModel
   val bottomSheetViewModel: BottomSheetViewModel
 
   @ContributesSubcomponent.Factory

--- a/bookOverview/src/main/kotlin/voice/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
@@ -1,0 +1,79 @@
+package voice.bookOverview.editBookCategory
+
+import androidx.lifecycle.ViewModel
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import voice.bookOverview.bottomSheet.BottomSheetItem
+import voice.bookOverview.bottomSheet.BottomSheetItemViewModel
+import voice.bookOverview.di.BookOverviewScope
+import voice.bookOverview.overview.BookOverviewCategory
+import voice.bookOverview.overview.category
+import voice.data.Book
+import voice.data.repo.BookRepository
+import java.time.Instant
+import javax.inject.Inject
+
+@BookOverviewScope
+@ContributesMultibinding(
+  scope = BookOverviewScope::class,
+  boundType = BottomSheetItemViewModel::class
+)
+class EditBookCategoryViewModel
+@Inject
+constructor(
+  private val repo: BookRepository,
+) : ViewModel(), BottomSheetItemViewModel {
+
+  private val scope = MainScope()
+
+  private val menuItems = listOf(
+    BottomSheetItem.BookCategoryMarkAsCurrent,
+    BottomSheetItem.BookCategoryMarkAsNotStarted,
+    BottomSheetItem.BookCategoryMarkAsCompleted,
+  )
+
+  override suspend fun items(bookId: Book.Id): List<BottomSheetItem> {
+    val book = repo.get(bookId) ?: return emptyList()
+    val bookOverviewCategory = book.category
+
+    return menuItems.filter { bottomSheetItem ->
+      when (bottomSheetItem) {
+        BottomSheetItem.BookCategoryMarkAsCurrent -> (bookOverviewCategory != BookOverviewCategory.CURRENT)
+        BottomSheetItem.BookCategoryMarkAsNotStarted -> (bookOverviewCategory != BookOverviewCategory.NOT_STARTED)
+        BottomSheetItem.BookCategoryMarkAsCompleted -> (bookOverviewCategory != BookOverviewCategory.FINISHED)
+        else -> false
+      }
+    }
+  }
+
+  override fun onItemClicked(bookId: Book.Id, item: BottomSheetItem) {
+    if (!menuItems.contains(item)) return
+
+    scope.launch {
+      val book = repo.get(bookId) ?: return@launch
+
+      val (currentChapter, positionInChapter) = when (item) {
+        BottomSheetItem.BookCategoryMarkAsCurrent -> {
+          Pair(book.chapters.first().id, 1L)
+        }
+        BottomSheetItem.BookCategoryMarkAsNotStarted -> {
+          Pair(book.chapters.first().id, 0L)
+        }
+        BottomSheetItem.BookCategoryMarkAsCompleted -> {
+          val lastChapter = book.chapters.last()
+          Pair(lastChapter.id, lastChapter.duration)
+        }
+        else -> return@launch
+      }
+
+      repo.updateBook(book.id) {
+        it.copy(
+          currentChapter = currentChapter,
+          positionInChapter = positionInChapter,
+          lastPlayedAt = Instant.now(),
+        )
+      }
+    }
+  }
+}

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -26,7 +26,10 @@
   <string name="download_book_cover">Cover from internet</string>
   <string name="pick_book_cover">Cover from file system</string>
   <string name="edit_book_title">Edit book</string>
-  l    <!--JumpToPosition-->
+  <string name="mark_as_completed">Mark as Completed</string>
+  <string name="mark_as_current">Mark as Current</string>
+  <string name="mark_as_not_started">Mark as Not Started Yet</string>
+  <!--JumpToPosition-->
   <!--BookAdding-->
   <string name="audiobook_folders_title">Audiobook folders</string>
   <!--PlaybackSpeed-->


### PR DESCRIPTION
Builds on @os97673 PR #1046, which I find useful when I copy books I've already read to my device.

This PR provides even more control on how books are categorized. The feature is of course subjective. Please close this PR if its not a desirable change. :)

For books in "Current" shelf:
![image](https://user-images.githubusercontent.com/304687/119258395-12ab7c80-bbe7-11eb-95ea-21c62dcc4a10.png)

For "Not started yet" shelf:
![image](https://user-images.githubusercontent.com/304687/119258445-3f5f9400-bbe7-11eb-9596-41e45ac54ea8.png)

For "Completed" shelf:
![image](https://user-images.githubusercontent.com/304687/119258511-8baad400-bbe7-11eb-83dd-5a4e39c2c9b8.png)
