### PR TITLE
Rebuild menu for selected book on orientation change

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/BottomSheetViewModel.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/BottomSheetViewModel.kt
@@ -17,11 +17,9 @@ class BottomSheetViewModel
 
   private val _state: MutableState<EditBookBottomSheetState> = mutableStateOf(EditBookBottomSheetState(emptyList()))
   internal val state: State<EditBookBottomSheetState> get() = _state
-  private var bookId: Book.Id? = null
   private val scope = MainScope()
 
   internal fun bookSelected(bookId: Book.Id) {
-    this.bookId = bookId
     scope.launch {
       val items = viewModels.flatMap { it.items(bookId) }
         .toSet()
@@ -30,8 +28,7 @@ class BottomSheetViewModel
     }
   }
 
-  internal fun onItemClick(item: BottomSheetItem) {
-    val bookId = bookId ?: return
+  internal fun onItemClick(bookId: Book.Id, item: BottomSheetItem) {
     viewModels.forEach {
       it.onItemClicked(bookId, item)
     }

--- a/bookOverview/src/main/kotlin/voice/bookOverview/views/BookOverview.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/views/BookOverview.kt
@@ -13,10 +13,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -66,6 +69,17 @@ fun BookOverviewScreen(
   val scope = rememberCoroutineScope()
 
   val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+
+  val selectedBook: MutableState<Book.Id?> = rememberSaveable { mutableStateOf(null) }
+
+  LaunchedEffect(bottomSheetState.isVisible) {
+    val book = selectedBook.value ?: return@LaunchedEffect
+
+    scope.launch {
+      bottomSheetViewModel.bookSelected(book)
+    }
+  }
+
   ModalBottomSheetLayout(
     sheetState = bottomSheetState,
     sheetContent = {
@@ -87,7 +101,7 @@ fun BookOverviewScreen(
       onBookClick = navigator::toBook,
       onBookLongClick = { bookId ->
         scope.launch {
-          bottomSheetViewModel.bookSelected(bookId)
+          selectedBook.value = bookId
           bottomSheetState.show()
         }
       },

--- a/bookOverview/src/main/kotlin/voice/bookOverview/views/BookOverview.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/views/BookOverview.kt
@@ -88,7 +88,9 @@ fun BookOverviewScreen(
           scope.launch {
             delay(300)
             bottomSheetState.hide()
-            bottomSheetViewModel.onItemClick(item)
+
+            val book = selectedBook.value ?: return@launch
+            bottomSheetViewModel.onItemClick(book, item)
           }
         }
       }


### PR DESCRIPTION
PR #1341 appears to have an issue with repopulating the menu on orientation change. `EditBookBottomSheetState.items` becomes an empty list. Please review.