### PR TITLE
Add "audiobook" to cover from internet search

### DIFF
--- a/app/src/main/kotlin/voice/app/features/imagepicker/CoverFromInternetController.kt
+++ b/app/src/main/kotlin/voice/app/features/imagepicker/CoverFromInternetController.kt
@@ -54,7 +54,7 @@ class CoverFromInternetController(bundle: Bundle) : ViewBindingController<ImageP
     }
   }
   private val originalUrl by lazy {
-    val encodedSearch = URLEncoder.encode("${book.content.name} cover", Charsets.UTF_8.name())
+    val encodedSearch = URLEncoder.encode("${book.content.name} audiobook cover", Charsets.UTF_8.name())
     "https://www.google.com/search?safe=on&site=imghp" +
       "&tbm=isch&tbs=isz:lt,islt:qsvga&q=$encodedSearch"
   }


### PR DESCRIPTION
Currently the cover from internet image picker finds images that are taller than they are wide, like the cover of a printed book.

Searching instead for book title + "audiobook cover" returns square covers.