### PR TITLE
Fix auto rewind dialog title

### DIFF
--- a/settings/src/main/kotlin/voice/settings/views/AutoRewindRow.kt
+++ b/settings/src/main/kotlin/voice/settings/views/AutoRewindRow.kt
@@ -49,7 +49,7 @@ internal fun AutoRewindAmountDialog(
   onDismiss: () -> Unit,
 ) {
   TimeSettingDialog(
-    title = stringResource(R.string.pref_seek_time),
+    title = stringResource(R.string.pref_auto_rewind_title),
     currentSeconds = currentSeconds,
     minSeconds = 0,
     maxSeconds = 20,


### PR DESCRIPTION
The current title is "Skip amount" instead of "Auto rewind".