### PR TITLE
Fix: settings skip amount not reflected in skip buttons

### DIFF
--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayView.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayView.kt
@@ -74,6 +74,7 @@ import voice.common.recomposeHighlighter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 internal fun BookPlayView(
@@ -172,6 +173,7 @@ private fun BookPlayContent(
         SliderRow(viewState, onSeek = onSeek)
         Spacer(modifier = Modifier.size(16.dp))
         PlaybackRow(
+          seekTime = viewState.seekTime,
           playing = viewState.playing,
           onPlayClick = onPlayClick,
           onRewindClick = onRewindClick,
@@ -204,6 +206,7 @@ private fun BookPlayContent(
       SliderRow(viewState, onSeek = onSeek)
       Spacer(modifier = Modifier.size(16.dp))
       PlaybackRow(
+        seekTime = viewState.seekTime,
         playing = viewState.playing,
         onPlayClick = onPlayClick,
         onRewindClick = onRewindClick,
@@ -458,6 +461,7 @@ private fun ChapterRow(
 
 @Composable
 private fun PlaybackRow(
+  seekTime: Duration,
   playing: Boolean,
   onPlayClick: () -> Unit,
   onRewindClick: () -> Unit,
@@ -470,7 +474,7 @@ private fun PlaybackRow(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.Center,
   ) {
-    SkipButton(forward = false, onClick = onRewindClick)
+    SkipButton(seekTime, forward = false, onClick = onRewindClick)
     Spacer(modifier = Modifier.size(16.dp))
     FloatingActionButton(
       modifier = Modifier.size(80.dp),
@@ -487,12 +491,13 @@ private fun PlaybackRow(
       )
     }
     Spacer(modifier = Modifier.size(16.dp))
-    SkipButton(forward = true, onClick = onFastForwardClick)
+    SkipButton(seekTime, forward = true, onClick = onFastForwardClick)
   }
 }
 
 @Composable
 private fun SkipButton(
+  seekTime: Duration,
   forward: Boolean,
   onClick: () -> Unit,
 ) {
@@ -521,7 +526,7 @@ private fun SkipButton(
     )
     Text(
       modifier = Modifier.offset(y = (-10).dp),
-      text = "20s",
+      text = seekTime.toString(),
       style = MaterialTheme.typography.bodySmall,
     )
   }
@@ -619,6 +624,7 @@ private class BookPlayViewStatePreviewProvider : PreviewParameterProvider<BookPl
       skipSilence = true,
       sleepTime = 4.minutes,
       title = "Das Ende der Welt",
+      seekTime = ZERO
     )
     yield(initial)
     yield(

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
@@ -3,6 +3,7 @@ package voice.playbackScreen
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.datastore.core.DataStore
+import de.paulwoitaschek.flowpref.Pref
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -14,6 +15,7 @@ import voice.common.compose.ImmutableFile
 import voice.common.navigation.Destination
 import voice.common.navigation.Navigator
 import voice.common.pref.CurrentBook
+import voice.common.pref.PrefKeys
 import voice.data.durationMs
 import voice.data.markForPosition
 import voice.data.repo.BookRepository
@@ -24,8 +26,10 @@ import voice.playback.misc.VolumeGain
 import voice.playback.playstate.PlayStateManager
 import voice.sleepTimer.SleepTimer
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class BookPlayViewModel
 @Inject constructor(
@@ -39,6 +43,8 @@ class BookPlayViewModel
   private val bookmarkRepo: BookmarkRepo,
   private val volumeGainFormatter: VolumeGainFormatter,
   private val batteryOptimization: BatteryOptimization,
+  @Named(PrefKeys.SEEK_TIME)
+  private val seekTimePref: Pref<Int>,
 ) {
 
   private var askedToIgnoreBatteryOptimization = false
@@ -65,6 +71,7 @@ class BookPlayViewModel
     ) { book, playState, sleepTime ->
       val currentMark = book.currentChapter.markForPosition(book.content.positionInChapter)
       val hasMoreThanOneChapter = book.chapters.sumOf { it.chapterMarks.count() } > 1
+      val seekTime = seekTimePref.value.seconds
       BookPlayViewState(
         sleepTime = sleepTime,
         playing = playState == PlayStateManager.PlayState.Playing,
@@ -75,6 +82,7 @@ class BookPlayViewModel
         playedTime = (book.content.positionInChapter - currentMark.startMs).milliseconds,
         cover = book.content.cover?.let(::ImmutableFile),
         skipSilence = book.content.skipSilence,
+        seekTime = seekTime
       )
     }
   }

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
@@ -17,6 +17,7 @@ data class BookPlayViewState(
   val playing: Boolean,
   val cover: ImmutableFile?,
   val skipSilence: Boolean,
+  val seekTime: Duration
 )
 
 internal sealed interface BookPlayDialogViewState {


### PR DESCRIPTION
Fixes the issues mentioned in  #1666 and #1651 where the skip amount set in the settings is not reflected in the skip buttons of the audiobook player.