### PR TITLE
Fix aspect ratio of images in grid layout

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/views/GridBooks.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/views/GridBooks.kt
@@ -91,7 +91,7 @@ internal fun GridBook(
     Column {
       AsyncImage(
         modifier = Modifier
-          .aspectRatio(4F / 3F)
+          .aspectRatio(1F / 1F)
           .padding(start = 8.dp, end = 8.dp, top = 8.dp)
           .clip(RoundedCornerShape(8.dp)),
         contentScale = ContentScale.Crop,


### PR DESCRIPTION
Fixes the aspect ratio to 1:1 when in grid layout as requested by #1656.