### PR TITLE
Add okhttp proguard rules

### DIFF
--- a/app/proguard.pro
+++ b/app/proguard.pro
@@ -1,1 +1,6 @@
 -dontobfuscate
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**


### PR DESCRIPTION
The task minifyReleaseWithR8 had warnings because of missing classes used by OkHttp on non-android platforms, now (maybe because of a gradle/agp update) they turned into errors letting the build fail.
To ignore them, this was added to newer versions of OkHttp: https://github.com/square/okhttp/pull/7471
But Voice uses an older version
Here's the related issue: https://github.com/square/okhttp/issues/6258