### PR TITLE
Remove the wma recognition as it's not supported by exoplayer.

### DIFF
--- a/data/src/main/kotlin/voice/data/SupportedAudioFormats.kt
+++ b/data/src/main/kotlin/voice/data/SupportedAudioFormats.kt
@@ -23,6 +23,5 @@ val supportedAudioFormats = arrayOf(
   "rtx",
   "wav",
   "webm",
-  "wma",
   "xmf",
 )


### PR DESCRIPTION
Wma is currently not supported by exoplayer: https://github.com/google/ExoPlayer/issues/2155

Therefore, this PR removes the support for WMA file recognition.

Fixes #1831