### PR TITLE
Improve the detection of the default FolderMode

### DIFF
--- a/folderPicker/src/main/kotlin/voice/folderPicker/selectType/SelectFolderTypeViewModel.kt
+++ b/folderPicker/src/main/kotlin/voice/folderPicker/selectType/SelectFolderTypeViewModel.kt
@@ -35,6 +35,7 @@ class SelectFolderTypeViewModel
 
   private fun CachedDocumentFile.defaultFolderMode(): FolderMode {
     return when {
+      name in listOf("Audiobooks", "Hörbücher") -> FolderMode.Audiobooks
       children.any { it.isAudioFile() } && children.any { it.isDirectory } -> {
         FolderMode.Audiobooks
       }


### PR DESCRIPTION
When determining the default FolderMode, pick `Audiobooks` if the name indicates it.