### PR TITLE
Sort new audiobooks by new

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/overview/BookOverviewCategory.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/overview/BookOverviewCategory.kt
@@ -16,7 +16,7 @@ enum class BookOverviewCategory(
   ),
   NOT_STARTED(
     nameRes = StringsR.string.book_header_not_started,
-    comparator = BookComparator.ByName,
+    comparator = BookComparator.ByLastAdded,
   ),
   FINISHED(
     nameRes = StringsR.string.book_header_completed,

--- a/data/src/main/kotlin/voice/data/BookComparator.kt
+++ b/data/src/main/kotlin/voice/data/BookComparator.kt
@@ -16,4 +16,9 @@ enum class BookComparator(
       NaturalOrderComparator.stringComparator.compare(left.content.name, right.content.name)
     },
   ),
+  ByLastAdded(
+    compareByDescending<Book> {
+      it.content.addedAt
+    },
+  ),
 }


### PR DESCRIPTION
This allows the "new" category to order the books by their date added, which is the expected ordering for new content.