### PR TITLE
Fix bug where file name instead of folder name is chosen as audiobook title

### DIFF
--- a/scanner/src/main/kotlin/voice/app/scanner/BookParser.kt
+++ b/scanner/src/main/kotlin/voice/app/scanner/BookParser.kt
@@ -59,7 +59,7 @@ class BookParser
         author = analyzed?.author,
         lastPlayedAt = migrationSettings?.lastPlayedAtMillis?.let(Instant::ofEpochMilli)
           ?: Instant.EPOCH,
-        name = migrationMetaData?.name ?: analyzed?.bookName ?: analyzed?.chapterName ?: file.bookName(),
+        name = migrationMetaData?.name ?: analyzed?.bookName ?: file.bookName(),
         playbackSpeed = migrationSettings?.playbackSpeed
           ?: 1F,
         skipSilence = migrationSettings?.skipSilence


### PR DESCRIPTION
This should fix https://github.com/PaulWoitaschek/Voice/issues/2025 (at least I hope).

I tested it with two books: One with ID3 tags and one without, the tagged book was displayed as before, the book without tags now has the book folder name as expected (instead of the name of the first file.) 

Thanks a lot for developing this great application!