### PR TITLE
fix: use title tag as book name

### DIFF
--- a/app/src/androidTest/kotlin/voice/app/misc/MediaAnalyzerInstrumentationTest.kt
+++ b/app/src/androidTest/kotlin/voice/app/misc/MediaAnalyzerInstrumentationTest.kt
@@ -36,7 +36,7 @@ class MediaAnalyzerInstrumentationTest {
     analyze(R.raw.intact) shouldBe MediaAnalyzer.Metadata(
       duration = 119040,
       author = "Auphonic",
-      bookName = "Auphonic Examples",
+      bookName = "Auphonic Chapter Marks Demo",
       chapterName = "Auphonic Chapter Marks Demo",
       chapters = listOf(
         MarkData(0, "Intro"),

--- a/scanner/src/main/kotlin/voice/app/scanner/MediaAnalyzer.kt
+++ b/scanner/src/main/kotlin/voice/app/scanner/MediaAnalyzer.kt
@@ -20,7 +20,7 @@ class MediaAnalyzer
         duration = duration.seconds.inWholeMilliseconds,
         chapterName = result.findTag(TagType.Title) ?: file.nameWithoutExtension(),
         author = result.findTag(TagType.Artist),
-        bookName = result.findTag(TagType.Album),
+        bookName = result.findTag(TagType.Title),
         chapters = result.chapters.mapIndexed { index, metaDataChapter ->
           MarkData(
             startMs = metaDataChapter.start.inWholeMilliseconds,


### PR DESCRIPTION
Fixes an issue where the album tag was displayed instead of the title. This can be an issue with audio files that are part of a larger series, where the album is set to the series title instead of the episode title.


| Before                                                                                                                                             	| After                                                                                                                                                        	|
|----------------------------------------------------------------------------------------------------------------------------------------------------	|--------------------------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Listitem showing 'Auphonic Examples' as the title](https://github.com/PaulWoitaschek/Voice/assets/63370021/3e4ed910-35f9-4984-a7d3-d4a29adb1972) 	| ![Listitem showing 'Auphonic Chapter Marks Demo' as the title](https://github.com/PaulWoitaschek/Voice/assets/63370021/6136f45f-4cc4-4dcc-b187-00b258aa4007) 	|

For example, [Amberol](https://apps.gnome.org/Amberol/) correctly uses the title tag.
![Audio file in Amberol with correct title](https://github.com/PaulWoitaschek/Voice/assets/63370021/7588ac31-b329-4a0a-8abf-2af5052c3090)

Closes https://github.com/PaulWoitaschek/Voice/issues/2171

I was wondering what `chapterName` actually does. I couldn't find any use for it in the UI.