### PR TITLE
Add percent complete to overview

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/views/GridBooks.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/views/GridBooks.kt
@@ -115,7 +115,7 @@ internal fun GridBook(
       )
       Text(
         modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
-        text = book.remainingTime,
+        text = "${book.remainingTime} / ${(book.progress * 100).toInt()}%",
         style = MaterialTheme.typography.bodySmall,
       )
 

--- a/bookOverview/src/main/kotlin/voice/bookOverview/views/ListBooks.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/views/ListBooks.kt
@@ -114,7 +114,7 @@ internal fun ListBookRow(
             style = MaterialTheme.typography.bodyMedium,
           )
           Text(
-            text = book.remainingTime,
+            text = "${book.remainingTime} / ${(book.progress * 100).toInt()}%",
             style = MaterialTheme.typography.bodySmall,
           )
         }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="remove">Remove</string>
     <string name="play_current">Play current</string>
     <string name="book_header_current">Current</string>
-    <string name="book_header_not_started">Not started Yet</string>
+    <string name="book_header_not_started">Not started yet</string>
     <string name="book_header_completed">Completed</string>
     <string name="close">Close</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
- Add percent complete to book overview in both list and grid
- Also fix a small inconsistency in capitalization in an English string
- At least partially addresses #1422 
- Screenshot of current iteration

![share_5049838222961981259](https://github.com/PaulWoitaschek/Voice/assets/20686990/d33bc052-c186-401d-a2f0-724f53fdd218)

