### PR TITLE
Set max lines for title and ellipsize

### DIFF
--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/AppBarTitle.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/AppBarTitle.kt
@@ -2,8 +2,13 @@ package voice.playbackScreen.view
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 internal fun AppBarTitle(title: String) {
-  Text(text = title)
+  Text(
+    text = title,
+    overflow = TextOverflow.Ellipsis,
+    maxLines = 2
+  )
 }

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayView.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayView.kt
@@ -108,6 +108,17 @@ private class BookPlayViewStatePreviewProvider : PreviewParameterProvider<BookPl
       sleepTime = 4.minutes,
       title = "Das Ende der Welt",
     )
+    val longTitle = BookPlayViewState(
+      chapterName = "My Chapter",
+      showPreviousNextButtons = false,
+      cover = null,
+      duration = 10.minutes,
+      playedTime = 3.minutes,
+      playing = true,
+      skipSilence = true,
+      sleepTime = 4.minutes,
+      title = "American Eclipse - A Nation's Epic Race to Catch the Shadow of the Moon and Win the Glory of the World",
+    )
     yield(initial)
     yield(
       initial.copy(
@@ -117,5 +128,6 @@ private class BookPlayViewStatePreviewProvider : PreviewParameterProvider<BookPl
       ),
     )
     yield(initial.copy(chapterName = null))
+    yield(longTitle)
   }
 }


### PR DESCRIPTION
Long titles would previously be missing the start, and only show the end.

I've set the overflow to `Ellipsize`, which required setting maxLines. I set it to 2 based on the previews and my own device always having a max of 2.

Fixes #2360 (potentially).

![image](https://github.com/PaulWoitaschek/Voice/assets/389169/88057aaa-35e6-408c-911f-1f2dffb7587b)
