### PR TITLE
Add sleep at end of chapter

### DIFF
--- a/playback/src/main/kotlin/voice/playback/PlayerController.kt
+++ b/playback/src/main/kotlin/voice/playback/PlayerController.kt
@@ -148,9 +148,7 @@ class PlayerController
 
   fun pauseAtStart() = executeAfterPrepare {
     it.pause()
-    val bookId = currentBookStoreId.data.first() ?: return@executeAfterPrepare
-    val book = bookRepository.get(bookId) ?: return@executeAfterPrepare
-    it.seekTo(book.currentMark.startMs)
+    it.seekTo(0)
   }
 
   fun pauseAtTime(ms: Long) = executeAfterPrepare {

--- a/playback/src/main/kotlin/voice/playback/PlayerController.kt
+++ b/playback/src/main/kotlin/voice/playback/PlayerController.kt
@@ -29,6 +29,7 @@ import voice.playback.session.toMediaIdOrNull
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
+import kotlinx.coroutines.delay
 
 class PlayerController
 @Inject constructor(
@@ -148,6 +149,7 @@ class PlayerController
 
   fun pauseAtStart() = executeAfterPrepare {
     it.pause()
+    delay(100)
     it.seekTo(0)
   }
 

--- a/playback/src/main/kotlin/voice/playback/PlayerController.kt
+++ b/playback/src/main/kotlin/voice/playback/PlayerController.kt
@@ -146,6 +146,18 @@ class PlayerController
     controller.setPlaybackSpeed(speed)
   }
 
+  fun pauseAtStart() = executeAfterPrepare {
+    it.pause()
+    val bookId = currentBookStoreId.data.first() ?: return@executeAfterPrepare
+    val book = bookRepository.get(bookId) ?: return@executeAfterPrepare
+    it.seekTo(book.currentMark.startMs)
+  }
+
+  fun pauseAtTime(ms: Long) = executeAfterPrepare {
+    it.pause()
+    it.seekTo(ms)
+  }
+
   fun setGain(gain: Decibel) = executeAfterPrepare { controller ->
     controller.sendCustomCommand(CustomCommand.SetGain(gain))
   }

--- a/playback/src/main/kotlin/voice/playback/playstate/PlayStateDelegatingListener.kt
+++ b/playback/src/main/kotlin/voice/playback/playstate/PlayStateDelegatingListener.kt
@@ -1,10 +1,25 @@
 package voice.playback.playstate
 
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.PlayerMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import voice.data.repo.ChapterRepo
+import voice.playback.PlayerController
+import voice.playback.session.MediaId
+import voice.playback.session.toMediaIdOrNull
 import javax.inject.Inject
 
 class PlayStateDelegatingListener
-@Inject constructor(private val playStateManager: PlayStateManager) : Player.Listener {
+@Inject constructor(
+  private val playStateManager: PlayStateManager,
+  private val playerController: PlayerController,
+  private val chapterRepo: ChapterRepo,
+) : Player.Listener {
+  private val scope = CoroutineScope(Dispatchers.Main.immediate)
 
   private lateinit var player: Player
 
@@ -25,12 +40,47 @@ class PlayStateDelegatingListener
     updatePlayState()
   }
 
+  override fun onMediaItemTransition(
+    mediaItem: MediaItem?,
+    reason: Int,
+  ) {
+    if (playStateManager.sleepAtEoc) {
+      playStateManager.sleepAtEoc = false
+      playerController.pauseAtStart()
+    }
+    if (player is ExoPlayer) {
+      registerChapterMarkCallbacks(player as ExoPlayer)
+    }
+  }
+
   private fun updatePlayState() {
     val playbackState = player.playbackState
     playStateManager.playState = when {
       playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE -> PlayStateManager.PlayState.Paused
       player.playWhenReady -> PlayStateManager.PlayState.Playing
       else -> PlayStateManager.PlayState.Paused
+    }
+  }
+
+  private fun registerChapterMarkCallbacks(player: ExoPlayer) {
+    scope.launch {
+      val currentMediaItem = player.currentMediaItem ?: return@launch
+      val mediaId = currentMediaItem.mediaId.toMediaIdOrNull() ?: return@launch
+      if (mediaId !is MediaId.Chapter) return@launch
+      val marks = chapterRepo.get(mediaId.chapterId)?.chapterMarks?.filter { mark -> mark.startMs != 0L } ?: return@launch
+      val boundaryHandler = PlayerMessage.Target { _, payload ->
+        if (playStateManager.sleepAtEoc) {
+          playerController.pauseAtTime(payload as Long)
+          playStateManager.sleepAtEoc = false
+        }
+      }
+      marks.forEach { mark ->
+        player.createMessage(boundaryHandler)
+          .setPosition(mark.startMs)
+          .setPayload(mark.startMs)
+          .setDeleteAfterDelivery(false)
+          .send()
+      }
     }
   }
 }

--- a/playback/src/main/kotlin/voice/playback/playstate/PlayStateManager.kt
+++ b/playback/src/main/kotlin/voice/playback/playstate/PlayStateManager.kt
@@ -25,16 +25,4 @@ constructor() {
     Playing,
     Paused,
   }
-
-  // Sleep at eoc state
-  private val _sleepAtEoc = MutableStateFlow(false)
-
-  val sleepAtEocFlow: StateFlow<Boolean>
-    get() = _sleepAtEoc
-
-  var sleepAtEoc: Boolean
-    set(value) {
-      _sleepAtEoc.value = value
-    }
-    get() = _sleepAtEoc.value
 }

--- a/playback/src/main/kotlin/voice/playback/playstate/PlayStateManager.kt
+++ b/playback/src/main/kotlin/voice/playback/playstate/PlayStateManager.kt
@@ -25,4 +25,16 @@ constructor() {
     Playing,
     Paused,
   }
+
+  // Sleep at eoc state
+  private val _sleepAtEoc = MutableStateFlow(false)
+
+  val sleepAtEocFlow: StateFlow<Boolean>
+    get() = _sleepAtEoc
+
+  var sleepAtEoc: Boolean
+    set(value) {
+      _sleepAtEoc.value = value
+    }
+    get() = _sleepAtEoc.value
 }

--- a/playback/src/main/kotlin/voice/playback/session/SleepTimer.kt
+++ b/playback/src/main/kotlin/voice/playback/session/SleepTimer.kt
@@ -5,6 +5,7 @@ import kotlin.time.Duration
 
 interface SleepTimer {
   val leftSleepTimeFlow: Flow<Duration>
+  var sleepAtEoc: Boolean
   fun sleepTimerActive(): Boolean
   fun setActive(enable: Boolean)
   fun setEocActive(enable: Boolean)

--- a/playback/src/main/kotlin/voice/playback/session/SleepTimer.kt
+++ b/playback/src/main/kotlin/voice/playback/session/SleepTimer.kt
@@ -7,4 +7,5 @@ interface SleepTimer {
   val leftSleepTimeFlow: Flow<Duration>
   fun sleepTimerActive(): Boolean
   fun setActive(enable: Boolean)
+  fun setEocActive(enable: Boolean)
 }

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayController.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayController.kt
@@ -103,6 +103,7 @@ class BookPlayController(bundle: Bundle) : ComposeController(bundle) {
             onIncrementSleepTime = viewModel::incrementSleepTime,
             onDecrementSleepTime = viewModel::decrementSleepTime,
             onAcceptSleepTime = viewModel::onAcceptSleepTime,
+            onAcceptSleepAtEoc = viewModel::onAcceptSleepAtEoc,
           )
         }
       }

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
@@ -82,11 +82,13 @@ class BookPlayViewModel
     }.collectAsState()
 
     val sleepTime by remember { sleepTimer.leftSleepTimeFlow }.collectAsState()
+    val sleepAtEoc by remember { playStateManager.sleepAtEocFlow }.collectAsState()
 
     val currentMark = book.currentChapter.markForPosition(book.content.positionInChapter)
     val hasMoreThanOneChapter = book.chapters.sumOf { it.chapterMarks.count() } > 1
     return BookPlayViewState(
       sleepTime = sleepTime,
+      sleepEoc = sleepAtEoc,
       playing = playState == PlayStateManager.PlayState.Playing,
       title = book.content.name,
       showPreviousNextButtons = hasMoreThanOneChapter,
@@ -139,6 +141,13 @@ class BookPlayViewModel
         )
       }
       sleepTimer.setActive(time.minutes)
+      null
+    }
+  }
+
+  fun onAcceptSleepAtEoc() {
+    updateSleepTimeViewState {
+      sleepTimer.setEocActive(true)
       null
     }
   }

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
@@ -82,7 +82,7 @@ class BookPlayViewModel
     }.collectAsState()
 
     val sleepTime by remember { sleepTimer.leftSleepTimeFlow }.collectAsState()
-    val sleepAtEoc by remember { playStateManager.sleepAtEocFlow }.collectAsState()
+    val sleepAtEoc by remember { sleepTimer.sleepAtEocFlow }.collectAsState()
 
     val currentMark = book.currentChapter.markForPosition(book.content.positionInChapter)
     val hasMoreThanOneChapter = book.chapters.sumOf { it.chapterMarks.count() } > 1

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
@@ -13,6 +13,7 @@ data class BookPlayViewState(
   val showPreviousNextButtons: Boolean,
   val title: String,
   val sleepTime: Duration,
+  val sleepEoc: Boolean,
   val playedTime: Duration,
   val duration: Duration,
   val playing: Boolean,

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayAppBar.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayAppBar.kt
@@ -40,7 +40,7 @@ internal fun BookPlayAppBar(
   val appBarActions: @Composable RowScope.() -> Unit = {
     IconButton(onClick = onSleepTimerClick) {
       Icon(
-        imageVector = if (viewState.sleepTime == Duration.ZERO) {
+        imageVector = if (!viewState.sleepEoc && viewState.sleepTime == Duration.ZERO) {
           Icons.Outlined.Bedtime
         } else {
           Icons.Outlined.BedtimeOff

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayContent.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayContent.kt
@@ -34,6 +34,7 @@ internal fun BookPlayContent(
         cover = viewState.cover,
         onPlayClick = onPlayClick,
         sleepTime = viewState.sleepTime,
+        sleepEoc = viewState.sleepEoc,
         modifier = Modifier
           .fillMaxHeight()
           .weight(1F)
@@ -75,6 +76,7 @@ internal fun BookPlayContent(
         onPlayClick = onPlayClick,
         cover = viewState.cover,
         sleepTime = viewState.sleepTime,
+        sleepEoc = viewState.sleepEoc,
         modifier = Modifier
           .fillMaxWidth()
           .weight(1F)

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayView.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/BookPlayView.kt
@@ -106,6 +106,7 @@ private class BookPlayViewStatePreviewProvider : PreviewParameterProvider<BookPl
       playing = true,
       skipSilence = true,
       sleepTime = 4.minutes,
+      sleepEoc = false,
       title = "Das Ende der Welt",
     )
     yield(initial)

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/view/CoverRow.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/view/CoverRow.kt
@@ -9,21 +9,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import voice.common.compose.ImmutableFile
 import voice.common.formatTime
+import voice.strings.R
 import kotlin.time.Duration
 
 @Composable
 internal fun CoverRow(
   cover: ImmutableFile?,
   sleepTime: Duration,
+  sleepEoc: Boolean,
   onPlayClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Box(modifier) {
     Cover(onDoubleClick = onPlayClick, cover = cover)
-    if (sleepTime != Duration.ZERO) {
+    if (sleepTime != Duration.ZERO || sleepEoc) {
       Text(
         modifier = Modifier
           .align(Alignment.TopEnd)
@@ -33,10 +36,13 @@ internal fun CoverRow(
             shape = RoundedCornerShape(20.dp),
           )
           .padding(horizontal = 20.dp, vertical = 16.dp),
-        text = formatTime(
-          timeMs = sleepTime.inWholeMilliseconds,
-          durationMs = sleepTime.inWholeMilliseconds,
-        ),
+        text = when (sleepEoc) {
+          true -> stringResource(R.string.end_of_chapter)
+          false -> formatTime(
+            timeMs = sleepTime.inWholeMilliseconds,
+            durationMs = sleepTime.inWholeMilliseconds,
+          )
+        },
         color = Color.White,
       )
     }

--- a/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimer.kt
+++ b/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimer.kt
@@ -48,7 +48,7 @@ class SleepTimer
     }
   override val leftSleepTimeFlow: StateFlow<Duration> get() = _leftSleepTime
 
-  override fun sleepTimerActive(): Boolean = sleepJob?.isActive == true && leftSleepTime > Duration.ZERO
+  override fun sleepTimerActive(): Boolean = (sleepJob?.isActive == true && leftSleepTime > Duration.ZERO) || playStateManager.sleepAtEoc
 
   private var sleepJob: Job? = null
 
@@ -56,6 +56,13 @@ class SleepTimer
     Logger.i("enable=$enable")
     if (enable) {
       setActive()
+    } else {
+      cancel()
+    }
+  }
+  override fun setEocActive(enable: Boolean) {
+    if (enable) {
+      playStateManager.sleepAtEoc = true
     } else {
       cancel()
     }
@@ -126,5 +133,6 @@ class SleepTimer
     sleepJob?.cancel()
     leftSleepTime = Duration.ZERO
     playerController.setVolume(1F)
+    playStateManager.sleepAtEoc = false
   }
 }

--- a/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimer.kt
+++ b/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimer.kt
@@ -48,9 +48,20 @@ class SleepTimer
     }
   override val leftSleepTimeFlow: StateFlow<Duration> get() = _leftSleepTime
 
-  override fun sleepTimerActive(): Boolean = (sleepJob?.isActive == true && leftSleepTime > Duration.ZERO) || playStateManager.sleepAtEoc
+  override fun sleepTimerActive(): Boolean = (sleepJob?.isActive == true && leftSleepTime > Duration.ZERO) || sleepAtEoc
 
   private var sleepJob: Job? = null
+
+  private val _sleepAtEoc = MutableStateFlow(false)
+
+  val sleepAtEocFlow: StateFlow<Boolean>
+    get() = _sleepAtEoc
+
+  override var sleepAtEoc: Boolean
+    set(value) {
+      _sleepAtEoc.value = value
+    }
+    get() = _sleepAtEoc.value
 
   override fun setActive(enable: Boolean) {
     Logger.i("enable=$enable")
@@ -60,9 +71,10 @@ class SleepTimer
       cancel()
     }
   }
+
   override fun setEocActive(enable: Boolean) {
     if (enable) {
-      playStateManager.sleepAtEoc = true
+      sleepAtEoc = true
     } else {
       cancel()
     }
@@ -133,6 +145,6 @@ class SleepTimer
     sleepJob?.cancel()
     leftSleepTime = Duration.ZERO
     playerController.setVolume(1F)
-    playStateManager.sleepAtEoc = false
+    sleepAtEoc = false
   }
 }

--- a/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimerDialog.kt
+++ b/sleepTimer/src/main/kotlin/voice/sleepTimer/SleepTimerDialog.kt
@@ -35,6 +35,7 @@ fun SleepTimerDialog(
   onIncrementSleepTime: () -> Unit,
   onDecrementSleepTime: () -> Unit,
   onAcceptSleepTime: (Int) -> Unit,
+  onAcceptSleepAtEoc: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   ModalBottomSheet(
@@ -63,6 +64,15 @@ fun SleepTimerDialog(
           },
         )
       }
+      ListItem(
+        modifier = Modifier.clickable {
+          onAcceptSleepAtEoc()
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        headlineContent = {
+          Text(text = stringResource(id = StringsR.string.end_of_chapter))
+        },
+      )
       ListItem(
         modifier = Modifier.clickable {
           onAcceptSleepTime(viewState.customSleepTime)

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -92,6 +92,7 @@
     <string name="notification_sleep_timer_disable">Einschlaftimer ausschalten</string>
     <string name="play">Abspielen</string>
     <string name="pause">Pause</string>
+    <string name="end_of_chapter">Kapitelende</string>
     <string name="generic_error_message">Etwas ist schief gelaufen 😢</string>
     <string name="generic_error_retry">Erneut versuchen</string>
     <string name="cover_search_template_with_author">%1$s von %2$s Hörbuch Titelbild</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -94,6 +94,7 @@
     <string name="media_session_recent">Reciente</string>
     <string name="pause">Pausar</string>
     <string name="play">Reproducir</string>
+    <string name="end_of_chapter">Fin del capítulo</string>
     <string name="generic_error_retry">Reintentar</string>
     <string name="generic_error_message">Algo salió mal 😢</string>
     <string name="cover_search_template_no_author">%s portada del audiolibro</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="media_session_recent">Recent</string>
     <string name="notification_sleep_timer_enable">Enable Sleep Timer</string>
     <string name="notification_sleep_timer_disable">Disable Sleep Timer</string>
+    <string name="end_of_chapter">End of Chapter</string>
     <string name="generic_error_message">Something went wrong 😢</string>
     <string name="generic_error_retry">Retry</string>
     <string name="storage_bug_title">Permission required</string>


### PR DESCRIPTION
Hi, I'm back with an implementation of the sleep at end of chapter that works with chapter marks in a single media file.
Stops between media files are handled in the `onMediaItemTransition` listener . Additionally, for every chapter mark a callback is registered, that stops the playback if sleep at end of chapter is active when the mark is reached.