### PR TITLE
Automatically start sleep timer on time schedule

### DIFF
--- a/app/src/main/kotlin/voice/app/injection/PrefsModule.kt
+++ b/app/src/main/kotlin/voice/app/injection/PrefsModule.kt
@@ -15,9 +15,11 @@ import voice.bookOverview.BookMigrationExplanationQualifier
 import voice.bookOverview.BookMigrationExplanationShown
 import voice.common.AppScope
 import voice.common.BookId
+import voice.common.autoSleepTimer.AutoSleepTimer
 import voice.common.grid.GridMode
 import voice.common.pref.AuthorAudiobookFoldersStore
 import voice.common.pref.AutoRewindAmountStore
+import voice.common.pref.AutoSleepTimerStore
 import voice.common.pref.CurrentBookStore
 import voice.common.pref.DarkThemeStore
 import voice.common.pref.FadeOutStore
@@ -30,6 +32,7 @@ import voice.common.pref.SingleFolderAudiobookFoldersStore
 import voice.common.pref.SleepTimeStore
 import voice.common.serialization.UriSerializer
 import voice.datastore.VoiceDataStoreFactory
+import java.time.LocalTime
 import javax.inject.Singleton
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -108,6 +111,21 @@ object PrefsModule {
       serializer = Duration.serializer(),
       fileName = "sleepTime2",
       defaultValue = 20.minutes,
+    )
+  }
+
+  @Provides
+  @Singleton
+  @AutoSleepTimerStore
+  fun provideAutoSleepTimerPreference(factory: VoiceDataStoreFactory): DataStore<AutoSleepTimer> {
+    return factory.create(
+      AutoSleepTimer.serializer(),
+      AutoSleepTimer(
+        enabled = false,
+        startTime = LocalTime.of(22, 0),
+        endTime = LocalTime.of(6, 0),
+      ),
+      "autoSleepTimer",
     )
   }
 

--- a/common/src/main/kotlin/voice/common/autoSleepTimer/AutoSleepTimer.kt
+++ b/common/src/main/kotlin/voice/common/autoSleepTimer/AutoSleepTimer.kt
@@ -1,0 +1,14 @@
+package voice.common.autoSleepTimer
+
+import kotlinx.serialization.Serializable
+import voice.common.serialization.LocalTimeSerializer
+import java.time.LocalTime
+
+@Serializable
+data class AutoSleepTimer(
+  val enabled: Boolean,
+  @Serializable(with = LocalTimeSerializer::class)
+  val startTime: LocalTime,
+  @Serializable(with = LocalTimeSerializer::class)
+  val endTime: LocalTime,
+)

--- a/common/src/main/kotlin/voice/common/pref/PrefQualifiers.kt
+++ b/common/src/main/kotlin/voice/common/pref/PrefQualifiers.kt
@@ -37,3 +37,6 @@ annotation class DarkThemeStore
 
 @Qualifier
 annotation class FadeOutStore
+
+@Qualifier
+annotation class AutoSleepTimerStore

--- a/common/src/main/kotlin/voice/common/serialization/LocalTimeSerializer.kt
+++ b/common/src/main/kotlin/voice/common/serialization/LocalTimeSerializer.kt
@@ -1,0 +1,22 @@
+package voice.common.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalTime
+
+object LocalTimeSerializer : KSerializer<LocalTime> {
+
+  override val descriptor = PrimitiveSerialDescriptor("LocalTime", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): LocalTime = LocalTime.parse(decoder.decodeString())
+
+  override fun serialize(
+    encoder: Encoder,
+    value: LocalTime,
+  ) {
+    encoder.encodeString(value.toString())
+  }
+}

--- a/settings/src/main/kotlin/voice/settings/SettingsListener.kt
+++ b/settings/src/main/kotlin/voice/settings/SettingsListener.kt
@@ -13,4 +13,14 @@ interface SettingsListener {
   fun suggestIdea()
   fun openBugReport()
   fun openTranslations()
+  fun setAutoSleepTimer(checked: Boolean)
+  fun setAutoSleepTimerStart(
+    hour: Int,
+    minute: Int,
+  )
+
+  fun setAutoSleepTimerEnd(
+    hour: Int,
+    minute: Int,
+  )
 }

--- a/settings/src/main/kotlin/voice/settings/SettingsViewState.kt
+++ b/settings/src/main/kotlin/voice/settings/SettingsViewState.kt
@@ -1,5 +1,7 @@
 package voice.settings
 
+import voice.common.autoSleepTimer.AutoSleepTimer
+
 data class SettingsViewState(
   val useDarkTheme: Boolean,
   val showDarkThemePref: Boolean,
@@ -8,6 +10,7 @@ data class SettingsViewState(
   val appVersion: String,
   val dialog: Dialog?,
   val useGrid: Boolean,
+  val autoSleepTimer: AutoSleepTimer,
 ) {
 
   enum class Dialog {

--- a/settings/src/main/kotlin/voice/settings/views/AutoSleepTimerRow.kt
+++ b/settings/src/main/kotlin/voice/settings/views/AutoSleepTimerRow.kt
@@ -1,0 +1,35 @@
+package voice.settings.views
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bedtime
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import voice.strings.R as StringsR
+
+@Composable
+internal fun AutoSleepTimerRow(
+  autoSleepTimer: Boolean,
+  toggleAutoSleepTimer: (Boolean) -> Unit,
+) {
+  ListItem(
+    leadingContent = {
+      Icon(
+        imageVector = Icons.Outlined.Bedtime,
+        contentDescription = stringResource(StringsR.string.auto_sleep_timer),
+      )
+    },
+    headlineContent = {
+      Text(text = stringResource(id = StringsR.string.auto_sleep_timer))
+    },
+    trailingContent = {
+      Switch(
+        checked = autoSleepTimer,
+        onCheckedChange = toggleAutoSleepTimer,
+      )
+    },
+  )
+}

--- a/settings/src/main/kotlin/voice/settings/views/AutoSleepTimerSetting.kt
+++ b/settings/src/main/kotlin/voice/settings/views/AutoSleepTimerSetting.kt
@@ -1,0 +1,51 @@
+package voice.settings.views
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Composable
+internal fun AutoSleepTimerSetting(
+  autoSleepTimer: Boolean,
+  time: LocalTime,
+  label: String,
+  setAutoSleepTime: (Int, Int) -> Unit,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    val shouldShowTimePicker = remember { mutableStateOf(false) }
+    Text(
+      text = label,
+      color = LocalContentColor.current.copy(alpha = if (autoSleepTimer) 1.0F else 0.5F),
+    )
+    if (shouldShowTimePicker.value) {
+      TimePickerDialog(
+        time.hour,
+        time.minute,
+        { timePickerState: TimePickerState ->
+          setAutoSleepTime(timePickerState.hour, timePickerState.minute)
+          shouldShowTimePicker.value = false
+        },
+        { shouldShowTimePicker.value = false },
+      )
+    }
+    TextButton(
+      onClick = {
+        shouldShowTimePicker.value = true
+      },
+      enabled = autoSleepTimer,
+    ) {
+      Text(text = time.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)))
+    }
+  }
+}

--- a/settings/src/main/kotlin/voice/settings/views/Settings.kt
+++ b/settings/src/main/kotlin/voice/settings/views/Settings.kt
@@ -3,7 +3,10 @@ package voice.settings.views
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -30,12 +33,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.squareup.anvil.annotations.ContributesTo
 import voice.common.AppScope
+import voice.common.autoSleepTimer.AutoSleepTimer
 import voice.common.compose.VoiceTheme
 import voice.common.compose.rememberScoped
 import voice.common.rootComponentAs
 import voice.settings.SettingsListener
 import voice.settings.SettingsViewModel
 import voice.settings.SettingsViewState
+import java.time.LocalTime
 import voice.strings.R as StringsR
 
 @Composable
@@ -49,6 +54,11 @@ private fun SettingsPreview() {
     dialog = null,
     appVersion = "1.2.3",
     useGrid = true,
+    autoSleepTimer = AutoSleepTimer(
+      enabled = false,
+      startTime = LocalTime.of(22, 0),
+      endTime = LocalTime.of(6, 0),
+    ),
   )
   VoiceTheme {
     Settings(
@@ -66,6 +76,18 @@ private fun SettingsPreview() {
         override fun suggestIdea() {}
         override fun openBugReport() {}
         override fun toggleGrid() {}
+        override fun setAutoSleepTimer(checked: Boolean) {}
+        override fun setAutoSleepTimerStart(
+          hour: Int,
+          minute: Int,
+        ) {
+        }
+
+        override fun setAutoSleepTimerEnd(
+          hour: Int,
+          minute: Int,
+        ) {
+        }
       },
     )
   }
@@ -136,6 +158,30 @@ private fun Settings(
         AutoRewindRow(viewState.autoRewindInSeconds) {
           listener.onAutoRewindRowClick()
         }
+        AutoSleepTimerRow(
+          viewState.autoSleepTimer.enabled,
+          listener::setAutoSleepTimer,
+        )
+        ListItem(
+          leadingContent = { Spacer(Modifier.size(24.dp)) },
+          headlineContent = {
+            Row {
+              AutoSleepTimerSetting(
+                viewState.autoSleepTimer.enabled,
+                viewState.autoSleepTimer.startTime,
+                stringResource(id = StringsR.string.auto_sleep_timer_start),
+                listener::setAutoSleepTimerStart,
+              )
+              Spacer(Modifier.weight(weight = 1f, fill = true))
+              AutoSleepTimerSetting(
+                viewState.autoSleepTimer.enabled,
+                viewState.autoSleepTimer.endTime,
+                stringResource(id = StringsR.string.auto_sleep_timer_end),
+                listener::setAutoSleepTimerEnd,
+              )
+            }
+          },
+        )
         ListItem(
           modifier = Modifier.clickable { listener.suggestIdea() },
           leadingContent = { Icon(Icons.Outlined.Lightbulb, stringResource(StringsR.string.pref_suggest_idea)) },

--- a/settings/src/main/kotlin/voice/settings/views/TimePickerDialog.kt
+++ b/settings/src/main/kotlin/voice/settings/views/TimePickerDialog.kt
@@ -1,0 +1,47 @@
+package voice.settings.views
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import voice.strings.R as StringsR
+
+@Composable
+fun TimePickerDialog(
+  initialHour: Int,
+  initialMinute: Int,
+  onConfirm: (TimePickerState) -> Unit,
+  onDismiss: () -> Unit,
+) {
+  val timePickerState = rememberTimePickerState(
+    initialHour = initialHour,
+    initialMinute = initialMinute,
+  )
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    dismissButton = {
+      TextButton(onClick = { onDismiss() }) {
+        Text(stringResource(id = StringsR.string.dialog_cancel))
+      }
+    },
+    confirmButton = {
+      TextButton(
+        onClick = {
+          onConfirm(timePickerState)
+        },
+      ) {
+        Text(stringResource(id = StringsR.string.dialog_confirm))
+      }
+    },
+    text = {
+      TimePicker(
+        state = timePickerState,
+      )
+    },
+  )
+}

--- a/sleepTimer/src/main/kotlin/voice/sleepTimer/IsTimeInRange.kt
+++ b/sleepTimer/src/main/kotlin/voice/sleepTimer/IsTimeInRange.kt
@@ -1,0 +1,17 @@
+package voice.sleepTimer
+
+import java.time.LocalTime
+
+fun isTimeInRange(
+  currentTime: LocalTime,
+  startTime: LocalTime,
+  endTime: LocalTime,
+): Boolean {
+  return if (startTime <= endTime) {
+    // Standard case, start and end on the same day
+    currentTime.isAfter(startTime) && currentTime.isBefore(endTime)
+  } else {
+    // Range wraps around midnight
+    currentTime.isAfter(startTime) || currentTime.isBefore(endTime)
+  }
+}

--- a/sleepTimer/src/test/kotlin/voice/sleepTimer/IsTimeInRangeTest.kt
+++ b/sleepTimer/src/test/kotlin/voice/sleepTimer/IsTimeInRangeTest.kt
@@ -1,0 +1,37 @@
+package voice.sleepTimer
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import java.time.LocalTime
+
+class IsTimeInRangeTest {
+  @Test
+  fun rangeWrapsAroundMidnight() {
+    val startTime = LocalTime.of(22, 0)
+    val endTime = LocalTime.of(6, 0)
+    isTimeInRange(LocalTime.of(5, 59), startTime, endTime) shouldBe true
+    isTimeInRange(LocalTime.of(6, 0), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(12, 30), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(22, 0), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(22, 1), startTime, endTime) shouldBe true
+  }
+
+  @Test
+  fun startAndEndOnSameDay() {
+    val startTime = LocalTime.of(6, 0)
+    val endTime = LocalTime.of(22, 0)
+    isTimeInRange(LocalTime.of(5, 59), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(6, 1), startTime, endTime) shouldBe true
+    isTimeInRange(LocalTime.of(12, 5), startTime, endTime) shouldBe true
+    isTimeInRange(LocalTime.of(22, 0), startTime, endTime) shouldBe false
+  }
+
+  @Test
+  fun invalidRange() {
+    val startTime = LocalTime.of(6, 0)
+    val endTime = LocalTime.of(6, 0)
+    isTimeInRange(LocalTime.of(6, 0), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(6, 1), startTime, endTime) shouldBe false
+    isTimeInRange(LocalTime.of(12, 5), startTime, endTime) shouldBe false
+  }
+}

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -124,6 +124,9 @@
     <string name="sleep_timer.title">Sweet dreams! 🌙</string>
     <string name="sleep_timer.button.increment">Longer</string>
     <string name="sleep_timer.button.decrement">Shorter</string>
+    <string name="auto_sleep_timer">Start snooze timer on schedule</string>
+    <string name="auto_sleep_timer_start">Start time</string>
+    <string name="auto_sleep_timer_end">End time</string>
     <plurals name="minutes">
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>


### PR DESCRIPTION
Referring to [this feature request](https://github.com/PaulWoitaschek/Voice/discussions/1743). I implemented a new setting for the sleep timer where one can set a start and an end time. If the current local time is in-between the two, the sleep timer will start automatically on playback. I am using this feature on my own device already, but of course I'm open for any suggestions on UI changes or similar.
<img alt="sleep timer screen with sleep timer schedule turned off" src="https://github.com/user-attachments/assets/dd468a8f-b9eb-4cf7-8dcb-fa33d75899ec" height=400> <img alt="sleep timer screen with sleep timer schedule turned on" src="https://github.com/user-attachments/assets/6f85ce2e-2a1e-4726-9c99-107399ccbbbc" height=400> <img alt="open time picker dialog" src="https://github.com/user-attachments/assets/8f54d97b-7a40-47e2-b6de-40ca0faafea5" height=400>