### PR TITLE
fix: apply bottomSheet container color to items

### DIFF
--- a/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/BottomSheetContent.kt
+++ b/bookOverview/src/main/kotlin/voice/bookOverview/bottomSheet/BottomSheetContent.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,6 +22,7 @@ internal fun BottomSheetContent(
   Column {
     state.items.forEach { item ->
       ListItem(
+        colors = ListItemDefaults.colors(containerColor = BottomSheetDefaults.ContainerColor),
         modifier = Modifier.clickable {
           onItemClick(item)
         },


### PR DESCRIPTION
Fixes an issue, where the content of the bottomSheet would keep the default background color, instead of following the bottomSheet container color. This is especially noticeable when using stronger color schemes.

| Before                                                                                                                        	| After                                                                                                                             	|
|-------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------	|
| ![Bottomsheet with default background color](https://github.com/user-attachments/assets/05ef8409-7c76-4596-8c51-8537c0b24908) 	| ![Bottomsheet with bottomsheet background color](https://github.com/user-attachments/assets/8c632510-58d9-4259-9676-0499cd94383f) 	|