### PR TITLE
feat: redesign chapter selection

### DIFF
--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
@@ -27,7 +27,7 @@ internal fun SelectChapterDialog(
     onDismissRequest = { viewModel.dismissDialog() },
     content = {
       LazyColumn(
-        state = rememberLazyListState(initialFirstVisibleItemIndex = dialogState.selectedIndex ?: 0),
+        state = rememberLazyListState(initialFirstVisibleItemIndex = dialogState.selectedIndex?.minus(1)?.coerceAtLeast(0) ?: 0),
         content = {
           itemsIndexed(dialogState.chapters) { index, chapter ->
             ListItem(

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
@@ -1,6 +1,7 @@
 package voice.playbackScreen
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -8,13 +9,20 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Equalizer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import voice.strings.R as StringsR
 
@@ -30,16 +38,24 @@ internal fun SelectChapterDialog(
         state = rememberLazyListState(initialFirstVisibleItemIndex = dialogState.selectedIndex?.minus(1)?.coerceAtLeast(0) ?: 0),
         content = {
           itemsIndexed(dialogState.chapters) { index, chapter ->
+            val isCurrentChapter = dialogState.selectedIndex == index
+            val description = stringResource(StringsR.string.migration_detail_content_position_current_chapter_title)
+
             ListItem(
-              colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-              modifier = Modifier.clickable {
-                viewModel.onChapterClick(index)
-              },
+              colors = if (isCurrentChapter) ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+              else ListItemDefaults.colors(containerColor = Color.Transparent),
+              modifier = Modifier
+                .padding(3.dp)
+                .clip(shape = RoundedCornerShape(12.dp))
+                .semantics {
+                  selected = isCurrentChapter
+                  if (isCurrentChapter) contentDescription = description
+                }
+                .clickable {
+                  viewModel.onChapterClick(index)
+                },
               headlineContent = {
                 Text(text = chapter.name ?: "")
-              },
-              leadingContent = {
-                Text(text = (index + 1).toString())
               },
               trailingContent = {
                 if (dialogState.selectedIndex == index) {

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -22,10 +23,9 @@ internal fun SelectChapterDialog(
   dialogState: BookPlayDialogViewState.SelectChapterDialog,
   viewModel: BookPlayViewModel,
 ) {
-  AlertDialog(
+  ModalBottomSheet(
     onDismissRequest = { viewModel.dismissDialog() },
-    confirmButton = {},
-    text = {
+    content = {
       LazyColumn(
         state = rememberLazyListState(initialFirstVisibleItemIndex = dialogState.selectedIndex ?: 0),
         content = {

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
@@ -5,10 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Equalizer
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Icon
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -25,6 +21,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import voice.strings.R as StringsR
+import voice.common.formatTime
 
 @Composable
 internal fun SelectChapterDialog(
@@ -58,12 +55,7 @@ internal fun SelectChapterDialog(
                 Text(text = chapter.name ?: "")
               },
               trailingContent = {
-                if (dialogState.selectedIndex == index) {
-                  Icon(
-                    imageVector = Icons.Outlined.Equalizer,
-                    contentDescription = stringResource(id = StringsR.string.migration_detail_content_position_current_chapter_title),
-                  )
-                }
+                Text(text = formatTime(chapter.startMs))
               },
             )
           }


### PR DESCRIPTION
Redesigns the chapter selection to use a bottom sheet and better highlight the current chapter. The increased space improves the display of long chapter titles, as well as allowing to show the time when each chapter starts.

![Chapter bottom sheet](https://github.com/user-attachments/assets/c0f80ebb-cb39-4d33-9a60-8c3ed3c3ac1c)

Closes: https://github.com/PaulWoitaschek/Voice/issues/2265