### PR TITLE
fix: update chapter selection logic in BookPlayViewModel

### DIFF
--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewModel.kt
@@ -199,25 +199,28 @@ class BookPlayViewModel
   fun onCurrentChapterClick() {
     scope.launch {
       val book = bookRepository.get(bookId) ?: return@launch
-      val chapterMarks = book.chapters.flatMap {
-        it.chapterMarks
-      }
-      val selectedIndex = chapterMarks.indexOf(book.currentMark)
       _dialogState.value = BookPlayDialogViewState.SelectChapterDialog(
-        chapters = chapterMarks,
-        selectedIndex = selectedIndex.takeUnless { it == -1 },
+        items = book.chapters.flatMapIndexed { chapterIndex, chapter ->
+          chapter.chapterMarks.mapIndexed { markIndex, chapterMark ->
+            BookPlayDialogViewState.SelectChapterDialog.ItemViewState(
+              number = book.chapters.take(chapterIndex).sumOf { it.chapterMarks.count() } + markIndex + 1,
+              name = chapterMark.name ?: "",
+              active = chapterMark == book.currentMark && chapter == book.currentChapter,
+            )
+          }
+        },
       )
     }
   }
 
-  fun onChapterClick(index: Int) {
+  fun onChapterClick(number: Int) {
     scope.launch {
       val book = bookRepository.get(bookId) ?: return@launch
       var currentIndex = -1
       book.chapters.forEach { chapter ->
         chapter.chapterMarks.forEach { mark ->
           currentIndex++
-          if (currentIndex == index) {
+          if (currentIndex == number - 1) {
             player.setPosition(mark.startMs, chapter.id)
             _dialogState.value = null
             return@launch

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/BookPlayViewState.kt
@@ -2,7 +2,6 @@ package voice.playbackScreen
 
 import androidx.compose.runtime.Immutable
 import voice.common.compose.ImmutableFile
-import voice.data.ChapterMark
 import voice.playback.misc.Decibel
 import voice.sleepTimer.SleepTimerViewState
 import kotlin.time.Duration
@@ -39,10 +38,14 @@ internal sealed interface BookPlayDialogViewState {
     val maxGain: Decibel,
   ) : BookPlayDialogViewState
 
-  data class SelectChapterDialog(
-    val chapters: List<ChapterMark>,
-    val selectedIndex: Int?,
-  ) : BookPlayDialogViewState
+  data class SelectChapterDialog(val items: List<ItemViewState>) : BookPlayDialogViewState {
+
+    data class ItemViewState(
+      val number: Int,
+      val name: String,
+      val active: Boolean,
+    )
+  }
 
   @JvmInline
   value class SleepTimer(val viewState: SleepTimerViewState) : BookPlayDialogViewState

--- a/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
+++ b/playbackScreen/src/main/kotlin/voice/playbackScreen/SelectChapterDialog.kt
@@ -2,7 +2,7 @@ package voice.playbackScreen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Equalizer
@@ -26,26 +26,29 @@ internal fun SelectChapterDialog(
     onDismissRequest = { viewModel.dismissDialog() },
     confirmButton = {},
     text = {
+      val selectedIndex = dialogState.items.indexOfFirst { it.active }
+      // -1 because we want to show the previous chapter as well
+      val initialFirstVisibleItemIndex = (selectedIndex - 1).coerceAtLeast(0)
       LazyColumn(
-        state = rememberLazyListState(initialFirstVisibleItemIndex = dialogState.selectedIndex ?: 0),
+        state = rememberLazyListState(initialFirstVisibleItemIndex = initialFirstVisibleItemIndex),
         content = {
-          itemsIndexed(dialogState.chapters) { index, chapter ->
+          items(dialogState.items) { chapter ->
             ListItem(
               colors = ListItemDefaults.colors(containerColor = Color.Transparent),
               modifier = Modifier.clickable {
-                viewModel.onChapterClick(index)
+                viewModel.onChapterClick(chapter.number)
               },
               headlineContent = {
-                Text(text = chapter.name ?: "")
+                Text(text = chapter.name)
               },
               leadingContent = {
-                Text(text = (index + 1).toString())
+                Text(text = chapter.number.toString())
               },
               trailingContent = {
-                if (dialogState.selectedIndex == index) {
+                if (chapter.active) {
                   Icon(
                     imageVector = Icons.Outlined.Equalizer,
-                    contentDescription = stringResource(id = StringsR.string.migration_detail_content_position_current_chapter_title),
+                    contentDescription = stringResource(id = StringsR.string.playback_current_chapter),
                   )
                 }
               },

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -132,4 +132,5 @@
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>
     </plurals>
+    <string name="playback.current_chapter">Current chapter</string>
 </resources>


### PR DESCRIPTION
Previously, having identical chapter marks in several files would always lead to multiple chapters being selected as active.