### PR TITLE
feat: Add GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+{
+  "name": "Voice Android Dev",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/java:0-17",
+
+  "features": {
+    "ghcr.io/devcontainers/features/android-sdk:0": {
+      "installGradle": true,
+      "installNdks": false,
+      "version": "latest"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "fwcd.kotlin",
+        "sdeleuze.vscode-spring-boot", // Good Kotlin support
+        "editorconfig.editorconfig",
+        "dbaeumer.vscode-eslint" // For any potential web/JS parts or markdown linting
+      ]
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "./gradlew --version && ./gradlew tasks --all",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root",
+
+  "mounts": [
+    "source=${localEnv:HOME}/.gradle,target=/home/vscode/.gradle,type=bind,consistency=cached"
+  ],
+  "runArgs": ["--name=voice-devcontainer"],
+
+  "remoteEnv": {
+    "ANDROID_HOME": "/opt/sdk",
+    "ANDROID_SDK_ROOT": "/opt/sdk"
+  },
+  "postCreateCommand": "echo 'sdk.dir=/opt/sdk' > local.properties && ./gradlew --version && ./gradlew tasks --all"
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ Voice
 
 For complete details on features, development, and licensing, please visit our [documentation website](https://voice.woitaschek.de).
 
+## Development Setup
+
+### GitHub Codespaces
+
+This repository is configured for development using GitHub Codespaces. A `.devcontainer/devcontainer.json` file is included, which defines a development environment with all necessary dependencies for Android development, including:
+
+*   Java Development Kit (JDK)
+*   Android SDK and build tools
+*   Gradle
+*   Commonly used VS Code extensions for Kotlin and Android development
+
+**How to use:**
+
+1.  Navigate to the main page of the repository on GitHub.
+2.  Click the "**<> Code**" button.
+3.  Go to the "**Codespaces**" tab.
+4.  Click "**Create codespace on main**" (or your current branch).
+
+GitHub will set up a new Codespace based on the configuration. Once the Codespace is ready, it will open in a browser-based VS Code editor, or you can connect to it from your local VS Code instance.
+
+The Android SDK path and `local.properties` file should be automatically configured by the `postCreateCommand` in the `devcontainer.json`.
+
+You can then use the integrated terminal in VS Code to run Gradle commands as outlined in the [Developer Guidelines](.junie/guidelines.md), such as:
+
+*   Build the app: `./gradlew :app:assemblePlayProprietaryDebug`
+*   Run unit tests: `./gradlew voiceUnitTest`
+*   Lint and format: `./gradlew lintKotlin` / `./gradlew formatKotlin`
+
+### Local Setup
+
+For local development, ensure you have a compatible Java Development Kit (JDK) and the Android SDK installed. You will also need to create a `local.properties` file in the root of the project, pointing to your Android SDK installation, e.g.:
+
+```
+sdk.dir=/path/to/your/android/sdk
+```
+
+Refer to the [Developer Guidelines](.junie/guidelines.md) for more details on build variants and project structure.
+
 ## License
 
 This project is licensed under [GNU GPLv3](docs/license). By contributing, you agree to license your code under the same terms.


### PR DESCRIPTION
This commit introduces a devcontainer configuration (`.devcontainer/devcontainer.json`) to support development in GitHub Codespaces.

The configuration specifies a Java environment, includes the Android SDK feature, and installs common VS Code extensions beneficial for Kotlin and Android development.

It also sets `ANDROID_HOME` and creates a `local.properties` file via `postCreateCommand` to point to the SDK, facilitating a ready-to-use environment for building and testing the Voice Android app.

Additionally, the README.md has been updated with a 'Development Setup' section, guiding users on how to launch a Codespace and providing basic instructions for local setup.