### PR TITLE
fix: Fix Playback Speed bug on Samsung Devices

### DIFF
--- a/playback/src/main/kotlin/voice/playback/di/PlaybackModule.kt
+++ b/playback/src/main/kotlin/voice/playback/di/PlaybackModule.kt
@@ -70,9 +70,7 @@ object PlaybackModule {
         player.onAudioSessionIdChanged {
           volumeGain.audioSessionId = it
         }
-        val disableAudioOffload =
-          Build.MANUFACTURER.equals("samsung", ignoreCase = true) &&
-            Build.VERSION.SDK_INT < 35
+        val disableAudioOffload = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
         if (!disableAudioOffload) {
           // samsung being samsung 🤪
           // https://github.com/PaulWoitaschek/Voice/issues/2807


### PR DESCRIPTION
https://github.com/PaulWoitaschek/Voice/issues/2807

This is also happening on the latest Samsung version.
This PR completely disables audio offload for all Samsung devices.