### PR TITLE
integrated mediaButtonHandler to support custom actions for headset remotes

### DIFF
--- a/playback/src/main/kotlin/voice/playback/session/button/AbstractMediaButtonHandler.kt
+++ b/playback/src/main/kotlin/voice/playback/session/button/AbstractMediaButtonHandler.kt
@@ -1,0 +1,111 @@
+package voice.playback.session.button
+
+import android.util.Log
+import android.view.KeyEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlin.time.Duration.Companion.milliseconds
+
+abstract class AbstractMediaButtonHandler(
+  protected val scope: CoroutineScope,
+  protected val playingStatusCallback: (playing:Boolean?) -> Boolean,
+  protected var stopCallback: () -> Unit,
+  protected var clickActions: MutableList<MediaButtonHandlerClickAction> = mutableListOf(),
+  protected var holdActions: MutableList<MediaButtonHandlerClickAction> = mutableListOf(),
+  ): MediaButtonHandler {
+
+  override var handlerDelay = 1050.milliseconds
+  val handlerDelayWithoutHoldSupport = 650.milliseconds
+  var clickCount = 0
+  var buttonReleasedJob: Job? = null
+
+  private var lastAction: MediaButtonHandlerClickAction? = null
+
+
+  fun log(message: String) {
+    Log.d("MediaButtonHandler", message)
+  }
+
+  protected fun keyEventToString(keyEvent: KeyEvent?): String {
+    if(keyEvent == null) {
+      return "keyEvent is <null>"
+    }
+    val action = when (keyEvent.action) {
+      KeyEvent.ACTION_UP -> "ACTION_UP"
+      KeyEvent.ACTION_DOWN -> "ACTION_DOWN"
+      else -> "ACTION_UNKNOWN"
+    }
+    val keyCode = when (keyEvent.keyCode) {
+      KeyEvent.KEYCODE_HEADSETHOOK -> "KEYCODE_HEADSETHOOK"
+      KeyEvent.KEYCODE_MEDIA_PLAY -> "KEYCODE_MEDIA_PLAY"
+      KeyEvent.KEYCODE_MEDIA_PAUSE -> "KEYCODE_MEDIA_PAUSE"
+      KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> "KEYCODE_MEDIA_PLAY_PAUSE"
+      KeyEvent.KEYCODE_MEDIA_NEXT -> "KEYCODE_MEDIA_NEXT"
+      KeyEvent.KEYCODE_MEDIA_PREVIOUS -> "KEYCODE_MEDIA_PREVIOUS"
+      KeyEvent.KEYCODE_MEDIA_STOP -> "KEYCODE_MEDIA_STOP"
+      else -> "KEYCODE_UNKNOWN"
+    }
+    return "keyCode=$keyCode, action=$action, repeatCount=${keyEvent.repeatCount}, eventTime=${keyEvent.eventTime}, downTime=${keyEvent.downTime}"
+  }
+
+  override fun addClickAction(clicks: Int, callback: () -> Unit) {
+    clickActions.add(MediaButtonHandlerClickAction(clicks, callback))
+  }
+
+  override fun addHoldAction(clicksBeforeHold: Int, callback: () -> Unit) {
+    holdActions.add(MediaButtonHandlerClickAction(clicksBeforeHold, callback))
+  }
+  fun executeHoldAction(clickCount: Int) {
+    log("executeHoldAction: clickCount=$clickCount")
+    val action = holdActions.find{it -> it.clicks == clickCount}
+    if(action == null) {
+      log("executeHoldAction: no action found")
+    }
+    // progressive actions (like fastForward and rewind) only get called once
+    if(action?.progressive == false || action != lastAction) {
+      action?.callback?.invoke()
+    }
+  }
+
+  fun executeClickAction(clickCount: Int) {
+    log("executeClickAction: clickCount=$clickCount")
+
+    val action = clickActions.find{it -> it.clicks == clickCount}
+    if(action == null) {
+      log("executeClickAction: no action found")
+    }
+    action?.callback?.invoke()
+  }
+
+  fun updateClickCount(keyEvent: KeyEvent): KeyCodeResult {
+    when (keyEvent.keyCode) {
+      KeyEvent.KEYCODE_HEADSETHOOK,
+      KeyEvent.KEYCODE_MEDIA_PLAY,
+      KeyEvent.KEYCODE_MEDIA_PAUSE,
+      KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
+        clickCount++
+        log("=== handleCallMediaButton: Headset Hook/Play/ Pause, clickCount=$clickCount")
+      }
+
+      KeyEvent.KEYCODE_MEDIA_NEXT -> {
+        clickCount += 2
+        log("=== handleCallMediaButton: Media Next, clickCount=$clickCount")
+      }
+
+      KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+        clickCount += 3
+        log("=== handleCallMediaButton: Media Previous, clickCount=$clickCount")
+      }
+      KeyEvent.KEYCODE_MEDIA_STOP -> {
+        log("=== handleCallMediaButton: Media Stop, clickCount=$clickCount")
+        stopCallback.invoke()
+        buttonReleasedJob?.cancel()
+        return KeyCodeResult.StopPlayback
+      } else -> {
+      log("=== KeyCode:${keyEvent.keyCode}, clickCount=$clickCount")
+      return KeyCodeResult.NotHandled
+    }
+    }
+    return KeyCodeResult.Default
+  }
+}

--- a/playback/src/main/kotlin/voice/playback/session/button/KeyCodeResult.kt
+++ b/playback/src/main/kotlin/voice/playback/session/button/KeyCodeResult.kt
@@ -1,0 +1,7 @@
+package voice.playback.session.button
+
+enum class KeyCodeResult {
+  Default,
+  StopPlayback,
+  NotHandled
+}

--- a/playback/src/main/kotlin/voice/playback/session/button/KeyDownHandler.kt
+++ b/playback/src/main/kotlin/voice/playback/session/button/KeyDownHandler.kt
@@ -1,0 +1,118 @@
+package voice.playback.session.button
+
+import android.view.KeyEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+
+class KeyDownHandler(
+  scope: CoroutineScope,
+  playingStatusCallback: (playing:Boolean?) -> Boolean,
+  stopCallback: () -> Unit,
+  clickActions: MutableList<MediaButtonHandlerClickAction> = mutableListOf(),
+  holdActions: MutableList<MediaButtonHandlerClickAction> = mutableListOf()
+) : AbstractMediaButtonHandler(scope, playingStatusCallback, stopCallback, clickActions, holdActions) {
+
+  val holdEndedDelay = 150.milliseconds
+  val holdActionDelay = 850.milliseconds
+  var buttonHoldEndedJob: Job? = null
+  var repetitiveHoldJob: Job? = null
+  var wasPlaying: Boolean = false
+  var firstRepeatCount = 0
+
+
+  override fun handleKeyEvent(keyEvent: KeyEvent?): Boolean {
+    // ignore all events that are not KEY_DOWN
+    if(keyEvent?.action != KeyEvent.ACTION_DOWN) {
+      log("handleKeyEvent: IGNORE ${keyEventToString(keyEvent)}, clickCount=$clickCount")
+
+      // mark event as handled
+      return true
+    }
+
+    log("handleKeyEvent: ${keyEventToString(keyEvent)}, clickCount=$clickCount")
+
+    // timerdelay has +100ms to regard the time of a release before a hold
+    // sequence KEY_DOWN starts with handlerDelay, releasing takes 250ms and holding down takes 1000ms
+    // so DOWN + UP + DOWN_AND_HOLD sequence may need 1250ms or even more
+    val timerDelay = if(holdActions.isEmpty()) handlerDelayWithoutHoldSupport else handlerDelay + holdEndedDelay
+    val isRepeatedEvent = keyEvent.repeatCount > 0
+    val isFirstRepeatedEvent = isRepeatedEvent && firstRepeatCount == 0
+    // only increase the clickCount on non-clickPressed events
+    if(isFirstRepeatedEvent) {
+      wasPlaying = playingStatusCallback(null)
+      firstRepeatCount = keyEvent.repeatCount
+      log("firstRepeatedEvent, firstRepeatCount=$firstRepeatCount ")
+    } else if(!isRepeatedEvent) {
+      firstRepeatCount = 0
+      updateClickCount(keyEvent)
+      log("no repeatedEvent, updated clickCount=$clickCount ")
+    }
+
+    if(isRepeatedEvent) {
+      // first we need to cancel a possibly pending buttonReleaseJob
+      buttonReleasedJob?.cancel()
+
+      // then define what happens after the key is released after holding down
+      // this is also a delayed job, because KEY_UP is completely ignored
+      buttonHoldEndedJob?.cancel()
+      buttonHoldEndedJob = scope.launch {
+        log("buttonHoldEndedJob: scheduled")
+        delay(holdEndedDelay)
+        log("buttonHoldEndedJob: execute")
+
+        // cancel repetiveHoldJob to prevent it from executing after
+        repetitiveHoldJob?.cancel()
+        buttonReleasedJob?.cancel()
+        clickCount = 0
+        log("buttonHoldEndedJob: wasPlaying=$wasPlaying")
+        playingStatusCallback(wasPlaying)
+      }
+
+      // if the repetitive job has already been queued before and is not completed yet, do nothing
+      if(repetitiveHoldJob?.isCompleted == false) {
+        log("repetitiveHoldJob still running, do nothing")
+        return true
+      }
+
+      // if job is null or is completed, requeue executeHoldAction with same amount of clicks
+      repetitiveHoldJob = scope.launch {
+        log("repetitiveHoldJob queued with clickCount=$clickCount")
+        // delay only if not first execution
+        if(!isFirstRepeatedEvent) {
+          delay(holdActionDelay)
+        }
+        executeHoldAction(clickCount)
+        log("repetitiveHoldJob executed with clickCount=$clickCount")
+      }
+      return true
+    }
+
+    // cancel all running jobs on a new click
+    repetitiveHoldJob?.cancel()
+    buttonReleasedJob?.cancel()
+    buttonHoldEndedJob?.cancel()
+
+    wasPlaying = playingStatusCallback(null) // player.isPlaying
+    buttonReleasedJob = scope.launch {
+      // delay(650);
+      log("clickReleasedJob scheduled: delay=${timerDelay.inWholeMilliseconds}ms, clicks=$clickCount, ${
+        keyEventToString(keyEvent)
+      }"
+      )
+      delay(timerDelay)
+      buttonHoldEndedJob?.cancel()
+      repetitiveHoldJob?.cancel()
+      log("clickReleasedJob executed: delay=${timerDelay.inWholeMilliseconds}ms, clicks=$clickCount, ${
+        keyEventToString(keyEvent)
+      }")
+      executeClickAction(clickCount)
+      clickCount = 0
+    }
+
+    return true
+  }
+
+}

--- a/playback/src/main/kotlin/voice/playback/session/button/MediaButtonHandler.kt
+++ b/playback/src/main/kotlin/voice/playback/session/button/MediaButtonHandler.kt
@@ -1,0 +1,13 @@
+package voice.playback.session.button
+
+import android.view.KeyEvent
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+interface MediaButtonHandler {
+  var handlerDelay: Duration
+
+  fun handleKeyEvent(keyEvent: KeyEvent?): Boolean
+  fun addClickAction(clicks: Int, callback: () -> Unit)
+  fun addHoldAction(clicksBeforeHold: Int, callback: () -> Unit)
+}

--- a/playback/src/main/kotlin/voice/playback/session/button/MediaButtonHandlerClickAction.kt
+++ b/playback/src/main/kotlin/voice/playback/session/button/MediaButtonHandlerClickAction.kt
@@ -1,0 +1,3 @@
+package voice.playback.session.button
+
+class MediaButtonHandlerClickAction(val clicks: Int, val callback: () -> Unit, val progressive:Boolean = false)


### PR DESCRIPTION
As "discussed" in https://github.com/PaulWoitaschek/Voice/discussions/2941, this pull request integrates a more or less sophisticated MediaButtonHandler, that supports custom actions on different click patterns, e.g.

- `Single Click` - Play / Pause
- `Double Click` - Next Track
- `Triple Click` - Previous Track
- `4 Clicks` - Step back
- `5 Clicks` - Step forward

If you're lacking the required equipment to test these changes with a headset remote, I'm willing to send you the required equipment for free (I'm from Germany, too), e.g.:

- [Apple USB-C headset adapter](https://www.amazon.de/exec/obidos/ASIN/B0D7MN4W7H/wwwgeschenke-inspiration-21)
- [Samsung EG920 headset wit remote](https://www.amazon.de/exec/obidos/ASIN/B00ZLTBXSS/wwwgeschenke-inspiration-21).

So just ask, if this is a problem and I'll send you an email. 

Since I would prefer to have 

- 4 clicks = `rewind` and
- 5 clicks = `fastForward`

and `VoicePlayer`does not seem to have a method for this yet, I created an [extra branch](https://github.com/PaulWoitaschek/Voice/compare/main...pilabor:Voice:voice-player-addons?expand=1) that implements these. I'm not sure, if you would like to have this in the code, so I excluded this change from the first PR. Another aspect we could discuss is the `longpress` pattern handling, which already is kind of integrated - but Android / media3 does NOT support this with version >= 13 (TIRAMISU) because the required events are delayed or dismissed (see linked discussion).

This PR also does not implement Dependency Injection for `MediaButtonHandler` or adds any `tests` (I'm not a professional Android developer) , so feel free to point me in the right direction with this or just rewrite the existing code to your liking.

Thanks for making this awesome app.