### PR TITLE
Fix a bug on adding multiple folders

### DIFF
--- a/core/ui/src/main/kotlin/voice/core/ui/ViewModel.kt
+++ b/core/ui/src/main/kotlin/voice/core/ui/ViewModel.kt
@@ -9,10 +9,10 @@ internal class HoldingViewModel<T>(val value: T) : ViewModel()
 
 @Composable
 inline fun <reified T> rememberScoped(
-  key: String = "",
+  vararg key: String,
   crossinline create: () -> T,
 ): T {
-  return viewModel(key = T::class.qualifiedName + key) {
+  return viewModel(key = T::class.qualifiedName + key.contentToString()) {
     HoldingViewModel(create())
   }.value
 }

--- a/features/folderPicker/src/main/kotlin/voice/features/folderPicker/selectType/SelectFolderType.kt
+++ b/features/folderPicker/src/main/kotlin/voice/features/folderPicker/selectType/SelectFolderType.kt
@@ -69,7 +69,7 @@ fun SelectFolderType(
   mode: Destination.SelectFolderType.Mode,
 ) {
   val context = LocalContext.current
-  val viewModel = rememberScoped {
+  val viewModel = rememberScoped(uri.toString(), mode.name) {
     rootGraphAs<SelectFolderTypeGraph>().selectFolderTypeViewModelFactory
       .create(
         uri = uri,


### PR DESCRIPTION
Recreate viewModel when uri or mode changes. Previously this was always re-using the same viewmodel with outdated parameters.

This is reproducible by:
- Going to the folder picker
- Selecting a folder A
- Going back and selecting another folder B

Now the first foler A is shown instead of B.

This PR fixes this.