### PR TITLE
feat: Add custom rewind and fast-forward buttons

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -9,6 +9,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaLibraryService
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -26,6 +27,7 @@ import voice.core.playback.playstate.PlayStateDelegatingListener
 import voice.core.playback.playstate.PositionUpdater
 import voice.core.playback.session.LibrarySessionCallback
 import voice.core.playback.session.PlaybackService
+import voice.core.strings.R as StringsR
 
 @BindingContainer
 @ContributesTo(PlaybackScope::class)
@@ -82,9 +84,24 @@ open class PlaybackModule {
     player: VoicePlayer,
     callback: LibrarySessionCallback,
     mainActivityIntentProvider: MainActivityIntentProvider,
+    context: Context,
   ): MediaLibraryService.MediaLibrarySession {
     return MediaLibraryService.MediaLibrarySession.Builder(service, player, callback)
       .setSessionActivity(mainActivityIntentProvider.toCurrentBook())
+      .setMediaButtonPreferences(
+        listOf(
+          CommandButton.Builder(CommandButton.ICON_SKIP_BACK)
+            .setDisplayName(context.getString(StringsR.string.rewind))
+            .setPlayerCommand(Player.COMMAND_SEEK_BACK)
+            .setSlots(CommandButton.SLOT_BACK)
+            .build(),
+          CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD)
+            .setDisplayName(context.getString(StringsR.string.fast_forward))
+            .setPlayerCommand(Player.COMMAND_SEEK_FORWARD)
+            .setSlots(CommandButton.SLOT_FORWARD)
+            .build(),
+        ),
+      )
       .build()
   }
 }


### PR DESCRIPTION
This commit adds custom rewind and fast-forward command buttons to the `MediaLibrarySession`. These buttons will be displayed in media controllers, such as Android Auto, providing users with explicit controls for seeking within the playback.