### PR TITLE
Fix: Keep dots in directory names

### DIFF
--- a/core/documentfile/src/main/kotlin/voice/core/documentfile/CachedDocumentFile.kt
+++ b/core/documentfile/src/main/kotlin/voice/core/documentfile/CachedDocumentFile.kt
@@ -21,8 +21,12 @@ fun CachedDocumentFile.nameWithoutExtension(): String {
       ?.takeUnless { it.isBlank() }
       ?: uri.toString()
   } else {
-    name.substringBeforeLast(".")
-      .takeUnless { it.isEmpty() }
-      ?: name
+    if (isFile) {
+      name.substringBeforeLast(".")
+        .takeUnless { it.isEmpty() }
+        ?: name
+    } else {
+      name
+    }
   }
 }

--- a/core/documentfile/src/test/kotlin/voice/core/documentfile/NameWithoutExtensionTest.kt
+++ b/core/documentfile/src/test/kotlin/voice/core/documentfile/NameWithoutExtensionTest.kt
@@ -1,0 +1,26 @@
+package voice.core.documentfile
+
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class NameWithoutExtensionTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  @Test
+  fun keepsDotsForDirectoryNames() {
+    val folder = testFolder.newFolder("Author.Name")
+
+    FileBasedDocumentFile(folder).nameWithoutExtension() shouldBe "Author.Name"
+  }
+
+  @Test
+  fun stripsExtensionForFileNames() {
+    val file = testFolder.newFile("Chapter.01.m4b")
+
+    FileBasedDocumentFile(file).nameWithoutExtension() shouldBe "Chapter.01"
+  }
+}


### PR DESCRIPTION
Previously, `nameWithoutExtension()` would incorrectly strip parts of a directory name if it contained a dot.

This change ensures that for directories, the full name is returned, while for files, the extension is correctly removed.

Fixes #3240