### PR TITLE
Fix: Handle empty or invalid chapter marks

### DIFF
--- a/core/data/api/src/test/kotlin/voice/core/data/ChapterTest.kt
+++ b/core/data/api/src/test/kotlin/voice/core/data/ChapterTest.kt
@@ -1,5 +1,6 @@
 package voice.core.data
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainInOrder
 import org.junit.Test
 import java.time.Instant
@@ -7,125 +8,199 @@ import java.time.Instant
 class ChapterTest {
 
   @Test
-  fun `filters duplicates`() {
-    test(
-      chapterStarts = listOf(0, 5, 5, 10),
-      expected = listOf(
-        MarkPosition(0, 4),
-        MarkPosition(5, 9),
-        MarkPosition(10, 19),
-      ),
-      duration = 20,
-    )
-  }
+  fun `duplicates are ignored`() = test2(
+    """
+    A#...................
+    B.....#..............
+    C.....#..............
+    D..........#.........
+    =AAAAABBBBBCCCCCCCCCC
+    """,
+  )
 
   @Test
-  fun `missing start position`() {
-    test(
-      chapterStarts = listOf(5, 10),
-      expected = listOf(
-        MarkPosition(0, 9),
-        MarkPosition(10, 19),
-      ),
-      duration = 20,
-    )
-  }
+  fun `missing start at 0 creates implicit leading mark`() = test2(
+    """
+    A.....#..............
+    B..........#.........
+    =AAAAAAAAAABBBBBBBBBB
+    """,
+  )
 
   @Test
-  fun `exceeding end position`() {
-    test(
-      chapterStarts = listOf(0, 10, 19),
-      expected = listOf(
-        MarkPosition(0, 9),
-        MarkPosition(10, 19),
-      ),
-      duration = 20,
-    )
-  }
+  fun `adjacent starts are ignored`() = test2(
+    """
+    A#...................
+    B.....#..............
+    C......#.............
+    D.......#............
+    E..........#.........
+    =AAAAABBBBBCCCCCCCCCC
+    """,
+  )
 
   @Test
-  fun `marks without duration`() {
-    test(
-      chapterStarts = listOf(0, 5, 6, 7, 10),
-      expected = listOf(
-        MarkPosition(0, 4),
-        MarkPosition(5, 9),
-        MarkPosition(10, 19),
-      ),
-    )
-  }
+  fun `start at last tick does not create a new segment`() = test2(
+    """
+    A#...................
+    B..........#.........
+    C...................#
+    =AAAAAAAAAABBBBBBBBBB
+    """,
+  )
 
   @Test
-  fun `on single chapter creates fallback`() {
-    test(
-      chapterStarts = listOf(5),
-      expected = listOf(
-        MarkPosition(0, 19),
-      ),
-    )
-  }
+  fun `no valid starts creates single fallback`() = test2(
+    """
+    =AAAAAAAAAAAAAAAAAAAA
+    """,
+  )
 
   @Test
-  fun `on missing chapters creates a single fallback`() {
-    test(
-      chapterStarts = listOf(),
-      expected = listOf(
-        MarkPosition(0, 19),
-      ),
-    )
-  }
+  fun `negative-only starts create single fallback`() = test2(
+    """
+    A@-2
+    B@-1
+    =AAAAAAAAAAAAAAAAAAAA
+    """,
+  )
 
   @Test
-  fun `negative start points are ignored`() {
-    test(
-      chapterStarts = listOf(-2, 5),
-      expected = listOf(
-        MarkPosition(0, 19),
-      ),
-    )
-  }
+  fun `single nonzero start creates single fallback`() = test2(
+    """
+    A.....#..............
+    =AAAAAAAAAAAAAAAAAAAA
+    """,
+  )
 
   @Test
-  fun `negative start points without following below zero are ignored`() {
-    test(
-      chapterStarts = listOf(-2, 0),
-      expected = listOf(
-        MarkPosition(0, 19),
-      ),
-    )
-  }
+  fun `first mark at tick 1 is ignored`() = test2(
+    """
+    A#...................
+    B.#..................
+    C.....#..............
+    =AAAAABBBBBBBBBBBBBBB
+    """,
+  )
 
-  @Test
-  fun `no duration mark on first position`() {
-    test(
-      chapterStarts = listOf(0, 1, 5),
-      expected = listOf(
-        MarkPosition(0, 4),
-        MarkPosition(5, 19),
-      ),
-      duration = 20,
-    )
-  }
+  /**
+   * Visual DSL:
+   *
+   * Start lines:
+   * - Timeline form: `A#.....` where first char is label and `#` marks the start tick.
+   * - Numeric form: `A@-2` for explicit (esp. negative) starts.
+   *
+   * Expected line (must be last):
+   * - `=AAAABBB...` (each char = one tick; length = duration)
+   */
+  private fun test2(case: String) {
+    val lines = case
+      .trimIndent()
+      .lineSequence()
+      .map { it.trimEnd() }
+      .filter { it.isNotBlank() }
+      .toList()
 
-  private fun test(
-    chapterStarts: List<Int>,
-    expected: List<MarkPosition>,
-    duration: Long = 20L,
-  ) {
-    val positions = Chapter(
+    check(lines.isNotEmpty()) { "Need at least an expected line (e.g. =AAAA)" }
+
+    val expectedLine = lines.last().trim()
+    check(expectedLine.startsWith("=")) { "Expected line must start with '=' (e.g. =AAABBB)" }
+
+    val expectedCoverage = expectedLine.drop(1)
+    val timelineLen = expectedCoverage.length
+    check(timelineLen > 0) { "Expected coverage must not be empty" }
+
+    val startLines = lines.dropLast(1)
+
+    // Enforce visual alignment: starts and expected must share the same timeline length.
+    startLines.forEach { line ->
+      when {
+        '@' in line -> Unit // numeric form
+        else -> {
+          check(line.length == timelineLen + 1) {
+            "Start line must be 1(label) + $timelineLen(timeline) chars, got ${line.length}: `$line`"
+          }
+          check(line.count { it == '#' } == 1) {
+            "Each timeline start line must contain exactly one '#': `$line`"
+          }
+        }
+      }
+    }
+
+    val marks = startLines.mapNotNull { line ->
+      when {
+        '@' in line -> {
+          val start = line.substringAfter('@').trim().toLongOrNull()
+            ?: error("Bad numeric start line: `$line` (expected like A@-2)")
+          MarkData(startMs = start, name = line.first().toString())
+        }
+        '#' in line -> {
+          val startTick = line.indexOf('#') - 1
+          MarkData(startMs = startTick.toLong(), name = line.first().toString())
+        }
+        else -> null
+      }
+    }
+
+    val duration = timelineLen.toLong()
+
+    val actualPositions = Chapter(
       duration = duration,
       fileLastModified = Instant.now(),
       id = ChapterId(""),
-      markData = chapterStarts.sorted().mapIndexed { index, i ->
-        MarkData(
-          startMs = i.toLong(),
-          name = "Mark $index",
-        )
-      },
+      markData = marks,
       name = "Chapter",
     ).chapterMarks.map { MarkPosition(it.startMs, it.endMs) }
 
-    positions.shouldContainInOrder(expected)
+    val expectedPositions = coverageToPositions(expectedCoverage)
+    val actualCoverage = positionsToCoverage(actualPositions, timelineLen)
+
+    withClue(
+      """
+      Expected: $expectedCoverage
+      Actual  : $actualCoverage
+      Starts  : ${marks.map { it.startMs }.sorted()}
+      Duration: $duration
+      """.trimIndent(),
+    ) {
+      actualPositions.shouldContainInOrder(expectedPositions)
+    }
+  }
+
+  private fun coverageToPositions(coverage: String): List<MarkPosition> {
+    if (coverage.isEmpty()) return emptyList()
+
+    val out = mutableListOf<MarkPosition>()
+    var start = 0
+    var current = coverage[0]
+
+    for (i in 1 until coverage.length) {
+      val c = coverage[i]
+      if (c != current) {
+        out += MarkPosition(start.toLong(), (i - 1).toLong())
+        start = i
+        current = c
+      }
+    }
+    out += MarkPosition(start.toLong(), (coverage.length - 1).toLong())
+    return out
+  }
+
+  private fun positionsToCoverage(
+    positions: List<MarkPosition>,
+    length: Int,
+  ): String {
+    if (length <= 0) return ""
+    val chars = CharArray(length) { '.' }
+
+    for ((idx, p) in positions.withIndex()) {
+      val label = ('A'.code + idx).toChar()
+      val s = p.start.toInt().coerceAtLeast(0)
+      val e = p.end.toInt().coerceAtMost(length - 1)
+      for (i in s..e) chars[i] = label
+    }
+
+    return String(chars)
   }
 
   data class MarkPosition(


### PR DESCRIPTION
When parsing chapter marks, if the `markData` was empty or contained only invalid entries (e.g., negative `startMs`), the parsing would fail.

This change ensures that:
- A default chapter spanning the entire duration is created if no valid marks are found.
- The `maxEndMs` is coerced to be at least 1 to prevent issues with very short durations.

Fixes #3306