### PR TITLE
feat: Refresh RemoteConfig on app start

### DIFF
--- a/core/remoteconfig/api/build.gradle.kts
+++ b/core/remoteconfig/api/build.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
   id("voice.library")
+  alias(libs.plugins.metro)
+}
+
+dependencies {
+  implementation(projects.core.initializer)
+  implementation(projects.core.common)
 }

--- a/core/remoteconfig/api/src/main/kotlin/voice/core/remoteconfig/api/LoadRemoteConfigOnAppStart.kt
+++ b/core/remoteconfig/api/src/main/kotlin/voice/core/remoteconfig/api/LoadRemoteConfigOnAppStart.kt
@@ -1,0 +1,24 @@
+package voice.core.remoteconfig.api
+
+import android.app.Application
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import kotlinx.coroutines.launch
+import voice.core.common.DispatcherProvider
+import voice.core.common.MainScope
+import voice.core.initializer.AppInitializer
+
+@ContributesIntoSet(AppScope::class)
+class LoadRemoteConfigOnAppStart(
+  private val remoteConfig: RemoteConfig,
+  dispatcherProvider: DispatcherProvider,
+) : AppInitializer {
+
+  private val mainScope = MainScope(dispatcherProvider)
+
+  override fun onAppStart(application: Application) {
+    mainScope.launch {
+      remoteConfig.refresh()
+    }
+  }
+}


### PR DESCRIPTION
This change introduces an `AppInitializer` to refresh the `RemoteConfig` values when the application starts.

By implementing `AppInitializer`, the `remoteConfig.refresh()` method is now called automatically on app startup, ensuring that the latest configuration values are fetched early in the application lifecycle.