### PR TITLE
Fix(bug): empty bottom sheet on book long-press.

### DIFF
--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/BottomSheetViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/BottomSheetViewModel.kt
@@ -23,7 +23,7 @@ class BottomSheetViewModel(private val viewModels: Set<@JvmSuppressWildcards Bot
 
   internal fun bookSelected(bookId: BookId) {
     this.bookId = bookId
-scope.launch {
+    scope.launch {
       val items = viewModels.flatMap { it.items(bookId) }
         .toSet()
         .sorted()

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/BottomSheetViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/BottomSheetViewModel.kt
@@ -4,12 +4,13 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import voice.core.data.BookId
 import voice.features.bookOverview.di.BookOverviewScope
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @Inject
 class BottomSheetViewModel(private val viewModels: Set<@JvmSuppressWildcards BottomSheetItemViewModel>) {
 
@@ -22,7 +23,7 @@ class BottomSheetViewModel(private val viewModels: Set<@JvmSuppressWildcards Bot
 
   internal fun bookSelected(bookId: BookId) {
     this.bookId = bookId
-    scope.launch {
+scope.launch {
       val items = viewModels.flatMap { it.items(bookId) }
         .toSet()
         .sorted()

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/deleteBook/DeleteBookViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/deleteBook/DeleteBookViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.documentfile.provider.DocumentFile
 import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import voice.core.data.BookId
@@ -14,7 +15,7 @@ import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
 import voice.features.bookOverview.di.BookOverviewScope
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
 class DeleteBookViewModel(
   private val application: Application,

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/di/BookOverviewGraph.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/di/BookOverviewGraph.kt
@@ -9,10 +9,9 @@ import voice.features.bookOverview.editTitle.EditBookTitleViewModel
 import voice.features.bookOverview.fileCover.FileCoverViewModel
 import voice.features.bookOverview.overview.BookOverviewViewModel
 
-annotation class BookOverviewScope
+abstract class BookOverviewScope private constructor()
 
 @GraphExtension(scope = BookOverviewScope::class)
-@BookOverviewScope
 interface BookOverviewGraph {
   val bookOverviewViewModel: BookOverviewViewModel
   val editBookTitleViewModel: EditBookTitleViewModel

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
@@ -1,6 +1,7 @@
 package voice.features.bookOverview.editBookCategory
 
 import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
 import voice.core.data.BookId
 import voice.core.data.repo.BookRepository
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
@@ -10,7 +11,7 @@ import voice.features.bookOverview.overview.BookOverviewCategory
 import voice.features.bookOverview.overview.category
 import java.time.Instant
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
 class EditBookCategoryViewModel(private val repo: BookRepository) : BottomSheetItemViewModel {
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editTitle/EditBookTitleViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editTitle/EditBookTitleViewModel.kt
@@ -3,6 +3,7 @@ package voice.features.bookOverview.editTitle
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import voice.core.data.BookId
@@ -11,7 +12,7 @@ import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
 import voice.features.bookOverview.di.BookOverviewScope
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
 class EditBookTitleViewModel(private val repo: BookRepository) : BottomSheetItemViewModel {
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/fileCover/FileCoverViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/fileCover/FileCoverViewModel.kt
@@ -2,6 +2,7 @@ package voice.features.bookOverview.fileCover
 
 import android.net.Uri
 import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
 import voice.core.data.BookId
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
@@ -9,7 +10,7 @@ import voice.features.bookOverview.di.BookOverviewScope
 import voice.navigation.Destination
 import voice.navigation.Navigator
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
 class FileCoverViewModel(private val navigator: Navigator) : BottomSheetItemViewModel {
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/internetCover/InternetCoverViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/internetCover/InternetCoverViewModel.kt
@@ -1,6 +1,7 @@
 package voice.features.bookOverview.internetCover
 
 import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
 import voice.core.data.BookId
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
@@ -8,7 +9,7 @@ import voice.features.bookOverview.di.BookOverviewScope
 import voice.navigation.Destination
 import voice.navigation.Navigator
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
 class InternetCoverViewModel(private val navigator: Navigator) : BottomSheetItemViewModel {
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -38,7 +39,7 @@ import voice.features.bookOverview.search.BookSearchViewState
 import voice.navigation.Destination
 import voice.navigation.Navigator
 
-@BookOverviewScope
+@SingleIn(BookOverviewScope::class)
 @Inject
 class BookOverviewViewModel(
   private val repo: BookRepository,


### PR DESCRIPTION
BookOverviewScope was an annotation class, which Metro 0.13.2 does not recognize as a valid aggregation scope. As a result, all ViewModels in the BookOverview graph were unscoped — new instances on every access.

This caused the bottom sheet to appear empty: bookSelected() populated one BottomSheetViewModel instance, but the recomposition triggered by showBottomSheet=true accessed a fresh instance with empty state.

Convert BookOverviewScope to an abstract class (Metro's required pattern for aggregation scopes) and apply @SingleIn(BookOverviewScope::class) to all seven ViewModels in the feature.