### PR TITLE
fix: use folder name instead of title for books with multiple files

### DIFF
--- a/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
@@ -46,7 +46,7 @@ internal class BookParser(
       author = analyzed?.artist,
       lastPlayedAt = Instant.EPOCH,
       name = analyzed?.album
-        ?: analyzed?.title?.takeIf { chapters.size == 1 }
+        ?: analyzed?.title?.takeIf { file.isFile }
         ?: file.bookName(),
       playbackSpeed = 1F,
       skipSilence = false,

--- a/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
@@ -36,7 +36,7 @@ internal class BookParser(
         author = analyzed?.artist,
         lastPlayedAt = Instant.EPOCH,
         name = analyzed?.album
-          ?: analyzed?.title
+          ?: analyzed?.title?.takeIf { chapters.size == 1 }
           ?: file.bookName(),
         playbackSpeed = 1F,
         skipSilence = false,

--- a/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
@@ -29,29 +29,38 @@ internal class BookParser(
     return contentRepo.getOrPut(id) {
       val uri = chapters.first().id.toUri()
       val analyzed = mediaAnalyzer.analyze(fileFactory.create(uri))
-      BookContent(
-        id = id,
-        isActive = true,
-        addedAt = Instant.now(),
-        author = analyzed?.artist,
-        lastPlayedAt = Instant.EPOCH,
-        name = analyzed?.album
-          ?: analyzed?.title?.takeIf { chapters.size == 1 }
-          ?: file.bookName(),
-        playbackSpeed = 1F,
-        skipSilence = false,
-        chapters = chapters.map { it.id },
-        positionInChapter = 0L,
-        currentChapter = chapters.first().id,
-        cover = null,
-        gain = 0F,
-        genre = analyzed?.genre,
-        narrator = analyzed?.narrator,
-        series = analyzed?.series,
-        part = analyzed?.part,
-      ).also {
-        validateIntegrity(it, chapters)
-      }
+      parse(chapters, id, analyzed, file)
+    }
+  }
+
+  fun parse(
+    chapters: List<Chapter>,
+    id: BookId,
+    analyzed: Metadata?,
+    file: CachedDocumentFile,
+  ): BookContent {
+    return BookContent(
+      id = id,
+      isActive = true,
+      addedAt = Instant.now(),
+      author = analyzed?.artist,
+      lastPlayedAt = Instant.EPOCH,
+      name = analyzed?.album
+        ?: analyzed?.title?.takeIf { chapters.size == 1 }
+        ?: file.bookName(),
+      playbackSpeed = 1F,
+      skipSilence = false,
+      chapters = chapters.map { it.id },
+      positionInChapter = 0L,
+      currentChapter = chapters.first().id,
+      cover = null,
+      gain = 0F,
+      genre = analyzed?.genre,
+      narrator = analyzed?.narrator,
+      series = analyzed?.series,
+      part = analyzed?.part,
+    ).also {
+      validateIntegrity(it, chapters)
     }
   }
 

--- a/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
@@ -28,7 +28,7 @@ class BookParserTest {
   )
 
   @Test
-  fun multiChapterBookUsesFolderNameWhenAlbumMissing() {
+  fun folderBookUsesFolderNameWhenAlbumMissing() {
     val bookFolder = testFolder.newFolder("My Audiobook")
     val chapters = listOf(
       chapter(File(bookFolder, "1.mp3").apply { createNewFile() }),
@@ -46,7 +46,22 @@ class BookParserTest {
   }
 
   @Test
-  fun singleChapterBookUsesTitleWhenAlbumMissing() {
+  fun folderBookWithSingleChapterStillUsesFolderName() {
+    val bookFolder = testFolder.newFolder("Harry Potter 3")
+    val chapters = listOf(chapter(File(bookFolder, "track01.mp3").apply { createNewFile() }))
+
+    val content = parser.parse(
+      chapters = chapters,
+      id = BookId(bookFolder.toUri()),
+      analyzed = metadata(album = null, title = "Track Title"),
+      file = FileBasedDocumentFile(bookFolder),
+    )
+
+    content.name shouldBe "Harry Potter 3"
+  }
+
+  @Test
+  fun singleFileBookUsesTitleWhenAlbumMissing() {
     val bookFile = testFolder.newFile("book.mp3")
     val chapters = listOf(chapter(bookFile))
 

--- a/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
@@ -1,0 +1,122 @@
+package voice.core.scanner
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.documentfile.FileBasedDocumentFile
+import java.io.File
+import java.time.Instant
+
+@RunWith(AndroidJUnit4::class)
+class BookParserTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  private val parser = BookParser(
+    contentRepo = mockk(),
+    mediaAnalyzer = mockk(),
+    fileFactory = mockk(),
+  )
+
+  @Test
+  fun multiChapterBookUsesFolderNameWhenAlbumMissing() {
+    val bookFolder = testFolder.newFolder("My Audiobook")
+    val chapters = listOf(
+      chapter(File(bookFolder, "1.mp3").apply { createNewFile() }),
+      chapter(File(bookFolder, "2.mp3").apply { createNewFile() }),
+    )
+
+    val content = parser.parse(
+      chapters = chapters,
+      id = BookId(bookFolder.toUri()),
+      analyzed = metadata(album = null, title = "First Chapter Title"),
+      file = FileBasedDocumentFile(bookFolder),
+    )
+
+    content.name shouldBe "My Audiobook"
+  }
+
+  @Test
+  fun singleChapterBookUsesTitleWhenAlbumMissing() {
+    val bookFile = testFolder.newFile("book.mp3")
+    val chapters = listOf(chapter(bookFile))
+
+    val content = parser.parse(
+      chapters = chapters,
+      id = BookId(bookFile.toUri()),
+      analyzed = metadata(album = null, title = "The Title"),
+      file = FileBasedDocumentFile(bookFile),
+    )
+
+    content.name shouldBe "The Title"
+  }
+
+  @Test
+  fun albumAlwaysWinsOverTitleAndFolderName() {
+    val bookFolder = testFolder.newFolder("Folder Name")
+    val chapters = listOf(
+      chapter(File(bookFolder, "1.mp3").apply { createNewFile() }),
+      chapter(File(bookFolder, "2.mp3").apply { createNewFile() }),
+    )
+
+    val content = parser.parse(
+      chapters = chapters,
+      id = BookId(bookFolder.toUri()),
+      analyzed = metadata(album = "Album Name", title = "First Chapter Title"),
+      file = FileBasedDocumentFile(bookFolder),
+    )
+
+    content.name shouldBe "Album Name"
+  }
+
+  @Test
+  fun missingMetadataFallsBackToFolderName() {
+    val bookFolder = testFolder.newFolder("Fallback Folder")
+    val chapters = listOf(
+      chapter(File(bookFolder, "1.mp3").apply { createNewFile() }),
+      chapter(File(bookFolder, "2.mp3").apply { createNewFile() }),
+    )
+
+    val content = parser.parse(
+      chapters = chapters,
+      id = BookId(bookFolder.toUri()),
+      analyzed = null,
+      file = FileBasedDocumentFile(bookFolder),
+    )
+
+    content.name shouldBe "Fallback Folder"
+  }
+
+  private fun chapter(file: File): Chapter = Chapter(
+    id = ChapterId(file.toUri()),
+    name = "Chapter",
+    duration = 1000L,
+    fileLastModified = Instant.EPOCH,
+    markData = emptyList(),
+  )
+
+  private fun metadata(
+    album: String?,
+    title: String?,
+  ): Metadata = Metadata(
+    duration = 1000L,
+    artist = null,
+    album = album,
+    title = title,
+    fileName = "file",
+    chapters = emptyList(),
+    genre = null,
+    narrator = null,
+    series = null,
+    part = null,
+  )
+}


### PR DESCRIPTION
This is a tiny fix for an issue that had been affecting me for a while. When a book had several files, the book title would be chosen from the metadata of the files, which would then show the first file/chapter title instead of the book title. For this case it would be better to simply use the folder name instead, same as was already done in the preview screen when adding a new folder recursively.

I understand this is an edge case, with multiple fixes over time, so hopefully the proposed fix gets all the nuance right.

This probably closes #3135