### PR TITLE
Fix Loading indicator delay

### DIFF
--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewTopBar.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewTopBar.kt
@@ -48,7 +48,7 @@ internal fun BookOverviewTopBar(
       showFolderPickerIcon = viewState.showFolderPickerIcon,
       searchViewState = viewState.searchViewState,
     )
-    var showLoading by remember { mutableStateOf(true) }
+    var showLoading by remember { mutableStateOf(false) }
     LaunchedEffect(viewState.isLoading) {
       if (viewState.isLoading) {
         delay(3.seconds)


### PR DESCRIPTION
The indicator was meant to show only after 3 seconds.