### PR TITLE
Fix(bug): book categorization

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
@@ -114,6 +114,8 @@ class PlayerController(
     }
   }
 
+  // Routed through executeAfterPrepare for symmetry with play()/playPause(); this means pause()
+  // will prepare the current book into the session if it isn't already loaded, then pause it.
   fun pause() = executeAfterPrepare { controller ->
     controller.pause()
   }

--- a/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
@@ -127,12 +127,12 @@ class PlayerController(
     expectedBookId: BookId,
     time: Long,
     chapterId: ChapterId,
-  ) = executeAfterPrepare { controller ->
-    val currentId = currentBookStoreId.data.first() ?: return@executeAfterPrepare
-    if (currentId != expectedBookId) return@executeAfterPrepare
-    val book = bookRepository.get(currentId) ?: return@executeAfterPrepare
-    val index = book.chapters.indexOfFirst { it.id == chapterId }
-    if (index != -1) {
+  ) {
+    scope.launch {
+      val index = resolveSeekIndex(expectedBookId, chapterId, currentBookStoreId, bookRepository)
+        ?: return@launch
+      val controller = awaitConnect() ?: return@launch
+      if (!maybePrepare(controller)) return@launch
       controller.seekTo(index, time)
       controller.pause()
     }
@@ -213,6 +213,19 @@ class PlayerController(
       null
     }
   }
+}
+
+internal suspend fun resolveSeekIndex(
+  expectedBookId: BookId,
+  chapterId: ChapterId,
+  currentBookStoreId: DataStore<BookId?>,
+  bookRepository: BookRepository,
+): Int? {
+  val currentId = currentBookStoreId.data.first() ?: return null
+  if (currentId != expectedBookId) return null
+  val book = bookRepository.get(currentId) ?: return null
+  val index = book.chapters.indexOfFirst { it.id == chapterId }
+  return if (index != -1) index else null
 }
 
 data class PlaybackPosition(

--- a/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
@@ -120,6 +120,24 @@ class PlayerController(
     controller.pause()
   }
 
+  // Seek and pause atomically in one coroutine to prevent PositionUpdater flushing a stale
+  // position between the two operations. The expectedBookId guard skips the call if the user
+  // navigated to a different book between the DB write and this invocation.
+  fun seekAndPauseIfCurrent(
+    expectedBookId: BookId,
+    time: Long,
+    chapterId: ChapterId,
+  ) = executeAfterPrepare { controller ->
+    val currentId = currentBookStoreId.data.first() ?: return@executeAfterPrepare
+    if (currentId != expectedBookId) return@executeAfterPrepare
+    val book = bookRepository.get(currentId) ?: return@executeAfterPrepare
+    val index = book.chapters.indexOfFirst { it.id == chapterId }
+    if (index != -1) {
+      controller.seekTo(index, time)
+      controller.pause()
+    }
+  }
+
   private suspend fun maybePrepare(controller: MediaController): Boolean {
     val bookId = currentBookStoreId.data.first() ?: return false
     if (controller.currentBookId() == bookId &&

--- a/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/PlayerController.kt
@@ -114,6 +114,10 @@ class PlayerController(
     }
   }
 
+  fun pause() = executeAfterPrepare { controller ->
+    controller.pause()
+  }
+
   private suspend fun maybePrepare(controller: MediaController): Boolean {
     val bookId = currentBookStoreId.data.first() ?: return false
     if (controller.currentBookId() == bookId &&

--- a/core/playback/src/test/kotlin/voice/core/playback/PlayerControllerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/PlayerControllerTest.kt
@@ -1,0 +1,65 @@
+package voice.core.playback
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.repo.BookRepository
+import voice.core.playback.session.search.book
+import java.time.Instant
+
+class PlayerControllerTest {
+
+  private val chapter1 = Chapter(
+    id = ChapterId("chapter-1"),
+    name = "Chapter 1",
+    duration = 10_000,
+    fileLastModified = Instant.EPOCH,
+    markData = emptyList(),
+  )
+  private val chapter2 = Chapter(
+    id = ChapterId("chapter-2"),
+    name = "Chapter 2",
+    duration = 20_000,
+    fileLastModified = Instant.EPOCH,
+    markData = emptyList(),
+  )
+  private val bookA = book(chapters = listOf(chapter1, chapter2))
+  private val bookB = book(chapters = listOf(chapter1))
+
+  @Test
+  fun `resolveSeekIndex returns chapter index when expectedBookId matches current book`() = runTest {
+    val store = MemoryDataStore<BookId?>(bookA.id)
+    val repo = mockk<BookRepository> { coEvery { get(bookA.id) } returns bookA }
+
+    resolveSeekIndex(bookA.id, chapter2.id, store, repo) shouldBe 1
+  }
+
+  @Test
+  fun `resolveSeekIndex returns null when expectedBookId does not match current book`() = runTest {
+    val store = MemoryDataStore<BookId?>(bookB.id)
+    val repo = mockk<BookRepository>()
+
+    resolveSeekIndex(bookA.id, chapter1.id, store, repo) shouldBe null
+  }
+
+  @Test
+  fun `resolveSeekIndex returns null when no book is loaded`() = runTest {
+    val store = MemoryDataStore<BookId?>(null)
+    val repo = mockk<BookRepository>()
+
+    resolveSeekIndex(bookA.id, chapter1.id, store, repo) shouldBe null
+  }
+
+  @Test
+  fun `resolveSeekIndex returns null when chapter is not found in book`() = runTest {
+    val store = MemoryDataStore<BookId?>(bookA.id)
+    val repo = mockk<BookRepository> { coEvery { get(bookA.id) } returns bookA }
+
+    resolveSeekIndex(bookA.id, ChapterId("unknown"), store, repo) shouldBe null
+  }
+}

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
@@ -1,12 +1,9 @@
 package voice.features.bookOverview.editBookCategory
 
-import androidx.datastore.core.DataStore
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.SingleIn
-import kotlinx.coroutines.flow.first
 import voice.core.data.BookId
 import voice.core.data.repo.BookRepository
-import voice.core.data.store.CurrentBookStore
 import voice.core.playback.PlayerController
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
@@ -19,7 +16,6 @@ import java.time.Instant
 @ContributesIntoSet(BookOverviewScope::class)
 class EditBookCategoryViewModel(
   private val repo: BookRepository,
-  @CurrentBookStore private val currentBookStore: DataStore<BookId?>,
   private val playerController: PlayerController,
 ) : BottomSheetItemViewModel {
 
@@ -69,9 +65,10 @@ class EditBookCategoryViewModel(
       )
     }
 
-    if (currentBookStore.data.first() == bookId) {
-      playerController.setPosition(positionInChapter, currentChapter)
-      playerController.pause()
-    }
+    playerController.seekAndPauseIfCurrent(
+      expectedBookId = bookId,
+      time = positionInChapter,
+      chapterId = currentChapter,
+    )
   }
 }

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModel.kt
@@ -1,9 +1,13 @@
 package voice.features.bookOverview.editBookCategory
 
+import androidx.datastore.core.DataStore
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.first
 import voice.core.data.BookId
 import voice.core.data.repo.BookRepository
+import voice.core.data.store.CurrentBookStore
+import voice.core.playback.PlayerController
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
 import voice.features.bookOverview.di.BookOverviewScope
@@ -13,7 +17,11 @@ import java.time.Instant
 
 @SingleIn(BookOverviewScope::class)
 @ContributesIntoSet(BookOverviewScope::class)
-class EditBookCategoryViewModel(private val repo: BookRepository) : BottomSheetItemViewModel {
+class EditBookCategoryViewModel(
+  private val repo: BookRepository,
+  @CurrentBookStore private val currentBookStore: DataStore<BookId?>,
+  private val playerController: PlayerController,
+) : BottomSheetItemViewModel {
 
   override suspend fun items(bookId: BookId): List<BottomSheetItem> {
     val book = repo.get(bookId) ?: return emptyList()
@@ -59,6 +67,11 @@ class EditBookCategoryViewModel(private val repo: BookRepository) : BottomSheetI
         positionInChapter = positionInChapter,
         lastPlayedAt = Instant.now(),
       )
+    }
+
+    if (currentBookStore.data.first() == bookId) {
+      playerController.setPosition(positionInChapter, currentChapter)
+      playerController.pause()
     }
   }
 }

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
@@ -24,9 +24,7 @@ class EditBookCategoryViewModelTest {
     coEvery { updateBook(book.id, any()) } just Runs
   }
 
-  private fun viewModel(
-    playerController: PlayerController = mockk(relaxed = true),
-  ): Pair<EditBookCategoryViewModel, PlayerController> {
+  private fun viewModel(playerController: PlayerController = mockk(relaxed = true)): Pair<EditBookCategoryViewModel, PlayerController> {
     val vm = EditBookCategoryViewModel(
       repo = repo,
       playerController = playerController,

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
@@ -1,0 +1,93 @@
+package voice.features.bookOverview.editBookCategory
+
+import androidx.datastore.core.DataStore
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import voice.core.data.BookId
+import voice.core.data.repo.BookRepository
+import voice.core.playback.PlayerController
+import voice.features.bookOverview.book
+import voice.features.bookOverview.bottomSheet.BottomSheetItem
+import voice.features.bookOverview.chapter
+
+class EditBookCategoryViewModelTest {
+
+  private val book = book(chapters = listOf(chapter(duration = 5_000), chapter(duration = 7_000)))
+
+  private val repo = mockk<BookRepository> {
+    coEvery { get(book.id) } returns book
+    coEvery { updateBook(book.id, any()) } just Runs
+  }
+
+  private fun viewModel(
+    currentBookStoreId: BookId? = null,
+    playerController: PlayerController = mockk(relaxed = true),
+  ): Pair<EditBookCategoryViewModel, PlayerController> {
+    val currentBookStore = mockk<DataStore<BookId?>> {
+      every { data } returns flowOf(currentBookStoreId)
+    }
+    val vm = EditBookCategoryViewModel(
+      repo = repo,
+      currentBookStore = currentBookStore,
+      playerController = playerController,
+    )
+    return vm to playerController
+  }
+
+  @Test
+  fun `MarkAsNotStarted on currently loaded book seeks player to 0 and pauses`() = runTest {
+    val (vm, player) = viewModel(currentBookStoreId = book.id)
+
+    vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsNotStarted)
+
+    coVerifyOrder {
+      player.setPosition(0L, book.chapters.first().id)
+      player.pause()
+    }
+  }
+
+  @Test
+  fun `MarkAsCurrent on currently loaded book seeks player to position 1 and pauses`() = runTest {
+    val (vm, player) = viewModel(currentBookStoreId = book.id)
+
+    vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsCurrent)
+
+    coVerifyOrder {
+      player.setPosition(1L, book.chapters.first().id)
+      player.pause()
+    }
+  }
+
+  @Test
+  fun `MarkAsCompleted on currently loaded book seeks player to last chapter duration and pauses`() = runTest {
+    val (vm, player) = viewModel(currentBookStoreId = book.id)
+
+    vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsCompleted)
+
+    val lastChapter = book.chapters.last()
+    coVerifyOrder {
+      player.setPosition(lastChapter.duration, lastChapter.id)
+      player.pause()
+    }
+  }
+
+  @Test
+  fun `recategorizing a non-loaded book does not touch the player`() = runTest {
+    val otherBookId = BookId("other")
+    val (vm, player) = viewModel(currentBookStoreId = otherBookId)
+
+    vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsNotStarted)
+
+    coVerify(exactly = 0) { player.setPosition(any(), any()) }
+    verify(exactly = 0) { player.pause() }
+  }
+}

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
@@ -63,7 +63,7 @@ class EditBookCategoryViewModelTest {
   }
 
   @Test
-  fun `recategorizing always calls seekAndPauseIfCurrent — guard lives in PlayerController`() = runTest {
+  fun `recategorizing always delegates to seekAndPauseIfCurrent regardless of which book is loaded`() = runTest {
     val (vm, player) = viewModel()
 
     vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsNotStarted)

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
@@ -5,11 +5,12 @@ import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
-import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import voice.core.data.BookId
@@ -32,12 +33,9 @@ class EditBookCategoryViewModelTest {
     currentBookStoreId: BookId? = null,
     playerController: PlayerController = mockk(relaxed = true),
   ): Pair<EditBookCategoryViewModel, PlayerController> {
-    val currentBookStore = mockk<DataStore<BookId?>> {
-      every { data } returns flowOf(currentBookStoreId)
-    }
     val vm = EditBookCategoryViewModel(
       repo = repo,
-      currentBookStore = currentBookStore,
+      currentBookStore = MemoryDataStore(currentBookStoreId),
       playerController = playerController,
     )
     return vm to playerController
@@ -89,5 +87,16 @@ class EditBookCategoryViewModelTest {
 
     coVerify(exactly = 0) { player.setPosition(any(), any()) }
     verify(exactly = 0) { player.pause() }
+  }
+}
+
+private class MemoryDataStore<T>(initial: T) : DataStore<T> {
+
+  private val value = MutableStateFlow(initial)
+
+  override val data: Flow<T> get() = value
+
+  override suspend fun updateData(transform: suspend (t: T) -> T): T {
+    return value.updateAndGet { transform(it) }
   }
 }

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/editBookCategory/EditBookCategoryViewModelTest.kt
@@ -1,16 +1,11 @@
 package voice.features.bookOverview.editBookCategory
 
-import androidx.datastore.core.DataStore
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import voice.core.data.BookId
@@ -30,12 +25,10 @@ class EditBookCategoryViewModelTest {
   }
 
   private fun viewModel(
-    currentBookStoreId: BookId? = null,
     playerController: PlayerController = mockk(relaxed = true),
   ): Pair<EditBookCategoryViewModel, PlayerController> {
     val vm = EditBookCategoryViewModel(
       repo = repo,
-      currentBookStore = MemoryDataStore(currentBookStoreId),
       playerController = playerController,
     )
     return vm to playerController
@@ -43,60 +36,39 @@ class EditBookCategoryViewModelTest {
 
   @Test
   fun `MarkAsNotStarted on currently loaded book seeks player to 0 and pauses`() = runTest {
-    val (vm, player) = viewModel(currentBookStoreId = book.id)
+    val (vm, player) = viewModel()
 
     vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsNotStarted)
 
-    coVerifyOrder {
-      player.setPosition(0L, book.chapters.first().id)
-      player.pause()
-    }
+    coVerify { player.seekAndPauseIfCurrent(book.id, 0L, book.chapters.first().id) }
   }
 
   @Test
   fun `MarkAsCurrent on currently loaded book seeks player to position 1 and pauses`() = runTest {
-    val (vm, player) = viewModel(currentBookStoreId = book.id)
+    val (vm, player) = viewModel()
 
     vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsCurrent)
 
-    coVerifyOrder {
-      player.setPosition(1L, book.chapters.first().id)
-      player.pause()
-    }
+    coVerify { player.seekAndPauseIfCurrent(book.id, 1L, book.chapters.first().id) }
   }
 
   @Test
   fun `MarkAsCompleted on currently loaded book seeks player to last chapter duration and pauses`() = runTest {
-    val (vm, player) = viewModel(currentBookStoreId = book.id)
+    val (vm, player) = viewModel()
 
     vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsCompleted)
 
     val lastChapter = book.chapters.last()
-    coVerifyOrder {
-      player.setPosition(lastChapter.duration, lastChapter.id)
-      player.pause()
-    }
+    coVerify { player.seekAndPauseIfCurrent(book.id, lastChapter.duration, lastChapter.id) }
   }
 
   @Test
-  fun `recategorizing a non-loaded book does not touch the player`() = runTest {
-    val otherBookId = BookId("other")
-    val (vm, player) = viewModel(currentBookStoreId = otherBookId)
+  fun `recategorizing always calls seekAndPauseIfCurrent — guard lives in PlayerController`() = runTest {
+    val (vm, player) = viewModel()
 
     vm.onItemClick(book.id, BottomSheetItem.BookCategoryMarkAsNotStarted)
 
-    coVerify(exactly = 0) { player.setPosition(any(), any()) }
+    coVerify(exactly = 1) { player.seekAndPauseIfCurrent(book.id, any(), any()) }
     verify(exactly = 0) { player.pause() }
-  }
-}
-
-private class MemoryDataStore<T>(initial: T) : DataStore<T> {
-
-  private val value = MutableStateFlow(initial)
-
-  override val data: Flow<T> get() = value
-
-  override suspend fun updateData(transform: suspend (t: T) -> T): T {
-    return value.updateAndGet { transform(it) }
   }
 }


### PR DESCRIPTION
# Fix: Mark-as-* on the currently loaded book reverts after navigation

## Problem

Recategorizing the currently loaded book (Mark as Not Started / Current /
Completed) reverts on the next overview render. The viewmodel writes the
new position to the DB, but the in-memory `Player` still holds the old
position and `PositionUpdater` flushes it back over the DB write.

This surfaced with #3454, which added `onPlayWhenReadyChanged`,
`onPlaybackStateChanged`, and `onMediaItemTransition` as flush triggers.
Previously `PositionUpdater` only wrote on seeks or a 400ms tick while
playing, so the viewmodel's DB-only write was silently safe for the
typical (paused/idle) categorize flow.

## Fix

In `EditBookCategoryViewModel`, after `repo.updateBook { … }`, if the
edited book is the one currently loaded, seek the player to the new
position and pause:

```kotlin
if (currentBookStore.data.first() == bookId) {
  playerController.setPosition(positionInChapter, currentChapter)
  playerController.pause()
}
```

Adds an unconditional `PlayerController.pause()` (the class only had
`playPause`, `pauseWithRewind`, and `pauseIfCurrentBookDifferentFrom`).

## Tests

New `EditBookCategoryViewModelTest` covering the three categories on the
loaded book and the no-op case on a non-loaded book.

## Files

- `core/playback/.../PlayerController.kt`
- `features/bookOverview/.../EditBookCategoryViewModel.kt`
- `features/bookOverview/.../EditBookCategoryViewModelTest.kt` (new)
