### PR TITLE
fix: Crop long title in AppBar (fixes #2853)

### DIFF
--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
@@ -1,14 +1,19 @@
 package voice.features.playbackScreen.view
 
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 
 @Composable
 internal fun AppBarTitle(title: String) {
   Text(
     text = title,
-    modifier = Modifier.basicMarquee(),
+    modifier = Modifier
+      .fillMaxWidth()
+      .clipToBounds()
+      .basicMarquee(),
   )
 }

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
@@ -2,18 +2,21 @@ package voice.features.playbackScreen.view
 
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun AppBarTitle(title: String) {
   Text(
     text = title,
     modifier = Modifier
-      .fillMaxWidth()
-      .clipToBounds()
-      .basicMarquee(),
+    .fillMaxWidth()
+    .padding(end = 16.dp)
+    .clipToBounds()
+    .basicMarquee(),
   )
 }

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/AppBarTitle.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -16,7 +15,6 @@ internal fun AppBarTitle(title: String) {
     modifier = Modifier
     .fillMaxWidth()
     .padding(end = 16.dp)
-    .clipToBounds()
     .basicMarquee(),
   )
 }


### PR DESCRIPTION
## Description
Fixes the issue where the long title on the right side.

## Changes
- Added `.fillMaxWidth()` to use available space
- Added `.clipToBounds()` to crop text at boundaries
- Kept `.basicMarquee()` for smooth scrolling animation

## Fixes
Fixes #2853 #3163