### PR TITLE
Speed up media scan

### DIFF
--- a/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
@@ -24,11 +24,12 @@ internal class BookParser(
   suspend fun parseAndStore(
     chapters: List<Chapter>,
     file: CachedDocumentFile,
+    firstChapterMetadata: Metadata? = null,
   ): BookContent {
     val id = BookId(file.uri)
     return contentRepo.getOrPut(id) {
-      val uri = chapters.first().id.toUri()
-      val analyzed = mediaAnalyzer.analyze(fileFactory.create(uri))
+      val analyzed = firstChapterMetadata
+        ?: mediaAnalyzer.analyze(fileFactory.create(chapters.first().id.toUri()))
       parse(chapters, id, analyzed, file)
     }
   }

--- a/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
@@ -3,11 +3,15 @@ package voice.core.scanner
 import dev.zacsweers.metro.Inject
 import voice.core.data.Chapter
 import voice.core.data.ChapterId
-import voice.core.data.isAudioFile
 import voice.core.data.repo.ChapterRepo
 import voice.core.data.repo.getOrPut
 import voice.core.documentfile.CachedDocumentFile
 import java.time.Instant
+
+internal class ChapterParseResult(
+  val chapters: List<Chapter>,
+  val firstFileMetadata: Metadata?,
+)
 
 @Inject
 internal class ChapterParser(
@@ -15,34 +19,30 @@ internal class ChapterParser(
   private val mediaAnalyzer: MediaAnalyzer,
 ) {
 
-  suspend fun parse(documentFile: CachedDocumentFile): List<Chapter> {
+  suspend fun parse(audioFiles: List<CachedDocumentFile>): ChapterParseResult {
     val result = mutableListOf<Chapter>()
+    val analyzedMetadata = mutableMapOf<ChapterId, Metadata>()
 
-    suspend fun parseChapters(file: CachedDocumentFile) {
-      if (file.isAudioFile()) {
-        val id = ChapterId(file.uri)
-        val chapter = chapterRepo.getOrPut(id, Instant.ofEpochMilli(file.lastModified)) {
-          val metaData = mediaAnalyzer.analyze(file) ?: return@getOrPut null
-          Chapter(
-            id = id,
-            duration = metaData.duration,
-            fileLastModified = Instant.ofEpochMilli(file.lastModified),
-            name = metaData.title ?: metaData.fileName,
-            markData = metaData.chapters,
-          )
-        }
-        if (chapter != null) {
-          result.add(chapter)
-        }
-      } else if (file.isDirectory) {
-        file.children
-          .forEach {
-            parseChapters(it)
-          }
+    audioFiles.forEach { file ->
+      val id = ChapterId(file.uri)
+      val chapter = chapterRepo.getOrPut(id, Instant.ofEpochMilli(file.lastModified)) {
+        val metaData = mediaAnalyzer.analyze(file) ?: return@getOrPut null
+        analyzedMetadata[id] = metaData
+        Chapter(
+          id = id,
+          duration = metaData.duration,
+          fileLastModified = Instant.ofEpochMilli(file.lastModified),
+          name = metaData.title ?: metaData.fileName,
+          markData = metaData.chapters,
+        )
+      }
+      if (chapter != null) {
+        result.add(chapter)
       }
     }
 
-    parseChapters(file = documentFile)
-    return result.sorted()
+    val sorted = result.sorted()
+    val firstFileMetadata = sorted.firstOrNull()?.let { analyzedMetadata[it.id] }
+    return ChapterParseResult(sorted, firstFileMetadata)
   }
 }

--- a/core/scanner/src/main/kotlin/voice/core/scanner/MediaScanner.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/MediaScanner.kt
@@ -2,7 +2,6 @@ package voice.core.scanner
 
 import dev.zacsweers.metro.Inject
 import voice.core.data.BookId
-import voice.core.data.audioFileCount
 import voice.core.data.folders.FolderType
 import voice.core.data.isAudioFile
 import voice.core.data.repo.BookContentRepo
@@ -47,7 +46,21 @@ internal class MediaScanner(
 
     contentRepo.setAllInactiveExcept(files.map { BookId(it.uri) })
 
-    val probeFile = folders.values.flatten().findProbeFile()
+    // Walk each candidate book exactly once and remember the audio files we find.
+    // Reused below for the permission probe, ordering and chapter parsing instead
+    // of walking the SAF tree three separate times.
+    val booksWithAudioFiles: List<Pair<CachedDocumentFile, List<CachedDocumentFile>>> = files.map { file ->
+      val audioFiles = if (file.isAudioFile()) {
+        listOf(file)
+      } else {
+        file.walk().filter { it.isAudioFile() }.toList()
+      }
+      file to audioFiles
+    }
+
+    val probeFile = booksWithAudioFiles.asSequence()
+      .flatMap { it.second.asSequence() }
+      .firstOrNull { it.uri.authority == "com.android.externalstorage.documents" }
     if (probeFile != null) {
       if (deviceHasPermissionBug.checkForBugAndSet(probeFile)) {
         Logger.w("Device has permission bug, aborting scan! Probed $probeFile")
@@ -55,25 +68,22 @@ internal class MediaScanner(
       }
     }
 
-    files
-      .sortedBy { it.audioFileCount() }
-      .forEach { file ->
-        scan(file)
+    booksWithAudioFiles
+      .sortedBy { it.second.size }
+      .forEach { (file, audioFiles) ->
+        scan(file, audioFiles)
       }
   }
 
-  private fun List<CachedDocumentFile>.findProbeFile(): CachedDocumentFile? {
-    return asSequence().flatMap { it.walk() }
-      .firstOrNull { child ->
-        child.isAudioFile() && child.uri.authority == "com.android.externalstorage.documents"
-      }
-  }
-
-  private suspend fun scan(file: CachedDocumentFile) {
-    val chapters = chapterParser.parse(file)
+  private suspend fun scan(
+    file: CachedDocumentFile,
+    audioFiles: List<CachedDocumentFile>,
+  ) {
+    val parseResult = chapterParser.parse(audioFiles)
+    val chapters = parseResult.chapters
     if (chapters.isEmpty()) return
 
-    val content = bookParser.parseAndStore(chapters, file)
+    val content = bookParser.parseAndStore(chapters, file, parseResult.firstFileMetadata)
 
     val chapterIds = chapters.map { it.id }
     val currentChapterGone = content.currentChapter !in chapterIds

--- a/core/scanner/src/test/kotlin/voice/core/scanner/ChapterParserTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/ChapterParserTest.kt
@@ -72,7 +72,9 @@ class ChapterParserTest {
         }
       },
     )
-    chapterParser.parse(FileBasedDocumentFile(audiobook))
+    val audioFiles = FileBasedDocumentFile(audiobook).children
+    chapterParser.parse(audioFiles)
+      .chapters
       .map { it.name }
       .shouldContainExactly(
         "Chapter 1",


### PR DESCRIPTION
## Summary

Reduces SAF (Storage Access Framework) traffic during media scans by reusing a single per-book directory walk and eliminating a redundant ExoPlayer analyze call for newly discovered books.

- Walk each candidate book exactly once into a `List<AudioFile>`, then reuse that list for the permission probe, ordering, and chapter parsing (previously three separate walks per book).
- Replace `sortedBy { it.audioFileCount() }` with `sortedBy { it.second.size }`. Kotlin's `sortedBy` does not cache its selector, so the old version re-walked each book's SAF tree on every comparison (`O(log N)` walks per book).
- `ChapterParser.parse` now takes the pre-walked list and returns `ChapterParseResult(chapters, firstFileMetadata)`. `BookParser.parseAndStore` accepts the optional first-chapter metadata so newly discovered books skip a duplicate `MediaAnalyzer.analyze` call. Null path preserves prior behavior.