### PR TITLE
Reuse chapter metadata for new books

### DIFF
--- a/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/BookParser.kt
@@ -1,6 +1,5 @@
 package voice.core.scanner
 
-import android.net.Uri
 import dev.zacsweers.metro.Inject
 import voice.core.data.Book
 import voice.core.data.BookContent
@@ -24,11 +23,12 @@ internal class BookParser(
   suspend fun parseAndStore(
     chapters: List<Chapter>,
     file: CachedDocumentFile,
+    firstChapterMetadata: Metadata?,
   ): BookContent {
     val id = BookId(file.uri)
     return contentRepo.getOrPut(id) {
-      val uri = chapters.first().id.toUri()
-      val analyzed = mediaAnalyzer.analyze(fileFactory.create(uri))
+      val analyzed = firstChapterMetadata
+        ?: mediaAnalyzer.analyze(fileFactory.create(chapters.first().id.toUri()))
       parse(chapters, id, analyzed, file)
     }
   }
@@ -91,10 +91,4 @@ internal fun validateIntegrity(
   // the init block performs integrity validation
   @Suppress("RETURN_VALUE_NOT_USED")
   Book(content, chapters)
-}
-
-internal fun Uri.filePath(): String? {
-  return pathSegments.lastOrNull()
-    ?.dropWhile { it != ':' }
-    ?.removePrefix(":")
 }

--- a/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
@@ -9,20 +9,27 @@ import voice.core.data.repo.getOrPut
 import voice.core.documentfile.CachedDocumentFile
 import java.time.Instant
 
+internal data class ChapterParseResult(
+  val chapters: List<Chapter>,
+  val firstChapterMetadata: Metadata?,
+)
+
 @Inject
 internal class ChapterParser(
   private val chapterRepo: ChapterRepo,
   private val mediaAnalyzer: MediaAnalyzer,
 ) {
 
-  suspend fun parse(documentFile: CachedDocumentFile): List<Chapter> {
+  suspend fun parse(documentFile: CachedDocumentFile): ChapterParseResult {
     val result = mutableListOf<Chapter>()
+    val analyzedMetadata = mutableMapOf<ChapterId, Metadata>()
 
     suspend fun parseChapters(file: CachedDocumentFile) {
       if (file.isAudioFile()) {
         val id = ChapterId(file.uri)
         val chapter = chapterRepo.getOrPut(id, Instant.ofEpochMilli(file.lastModified)) {
           val metaData = mediaAnalyzer.analyze(file) ?: return@getOrPut null
+          analyzedMetadata[id] = metaData
           Chapter(
             id = id,
             duration = metaData.duration,
@@ -43,6 +50,10 @@ internal class ChapterParser(
     }
 
     parseChapters(file = documentFile)
-    return result.sorted()
+    val chapters = result.sorted()
+    return ChapterParseResult(
+      chapters = chapters,
+      firstChapterMetadata = chapters.firstOrNull()?.let { analyzedMetadata[it.id] },
+    )
   }
 }

--- a/core/scanner/src/main/kotlin/voice/core/scanner/MediaScanner.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/MediaScanner.kt
@@ -70,10 +70,11 @@ internal class MediaScanner(
   }
 
   private suspend fun scan(file: CachedDocumentFile) {
-    val chapters = chapterParser.parse(file)
+    val parseResult = chapterParser.parse(file)
+    val chapters = parseResult.chapters
     if (chapters.isEmpty()) return
 
-    val content = bookParser.parseAndStore(chapters, file)
+    val content = bookParser.parseAndStore(chapters, file, parseResult.firstChapterMetadata)
 
     val chapterIds = chapters.map { it.id }
     val currentChapterGone = content.currentChapter !in chapterIds

--- a/core/scanner/src/test/kotlin/voice/core/scanner/ChapterParserTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/ChapterParserTest.kt
@@ -16,8 +16,6 @@ import voice.core.data.repo.ChapterRepoImpl
 import voice.core.documentfile.CachedDocumentFile
 import voice.core.documentfile.FileBasedDocumentFile
 import voice.core.documentfile.nameWithoutExtension
-import voice.core.scanner.ChapterParser
-import voice.core.scanner.Metadata
 
 @RunWith(AndroidJUnit4::class)
 class ChapterParserTest {
@@ -73,6 +71,7 @@ class ChapterParserTest {
       },
     )
     chapterParser.parse(FileBasedDocumentFile(audiobook))
+      .chapters
       .map { it.name }
       .shouldContainExactly(
         "Chapter 1",

--- a/core/scanner/src/test/kotlin/voice/core/scanner/MediaScannerTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/MediaScannerTest.kt
@@ -159,6 +159,17 @@ class MediaScannerTest {
   }
 
   @Test
+  fun newBookReusesFirstChapterMetadata() = test {
+    val folder = folder("book")
+    audioFile(parent = folder, "1.mp3")
+    audioFile(parent = folder, "2.mp3")
+
+    scan(FolderType.SingleFolder, folder)
+
+    analyzeCalls shouldBe 2
+  }
+
+  @Test
   fun scanAuthor() = test {
     val audioBooks = folder("audiobooks")
 
@@ -196,6 +207,7 @@ class MediaScannerTest {
     val bookContentRepo = BookContentRepoImpl(db.bookContentDao())
     private val chapterRepo = ChapterRepoImpl(db.chapterDao())
     private val mediaAnalyzer = mockk<MediaAnalyzer>()
+    var analyzeCalls = 0
     private val scanner = MediaScanner(
       contentRepo = bookContentRepo,
       chapterParser = ChapterParser(
@@ -234,6 +246,7 @@ class MediaScannerTest {
         }
         .also {
           coEvery { mediaAnalyzer.analyze(any()) } coAnswers {
+            analyzeCalls++
             Metadata(
               duration = 1000L,
               artist = "Author",


### PR DESCRIPTION
## Summary
- reuse metadata already parsed for the first chapter when creating new book content
- avoid a duplicate MediaAnalyzer analyze call for newly discovered books
- add a scanner regression test covering the analyze call count

Supersedes #3526 and includes the logical change to call analyze only once.