### PR TITLE
Re-scan files if their file-size changed

### DIFF
--- a/app/src/androidTest/kotlin/voice/app/SleepTimerIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/voice/app/SleepTimerIntegrationTest.kt
@@ -115,6 +115,7 @@ class SleepTimerIntegrationTest {
         MarkData(startMs = 0, name = "Mark 1"),
         MarkData(startMs = 1000, name = "Mark 2"),
       ),
+      fileSize = 0,
     )
 
     val bookContent = BookContent(

--- a/core/data/api/src/main/kotlin/voice/core/data/Chapter.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/Chapter.kt
@@ -2,6 +2,7 @@ package voice.core.data
 
 import android.net.Uri
 import androidx.core.net.toUri
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -20,6 +21,8 @@ public data class Chapter(
   val name: String?,
   val duration: Long,
   val fileLastModified: Instant,
+  @ColumnInfo(defaultValue = "0")
+  val fileSize: Long,
   val markData: List<MarkData>,
 ) : Comparable<Chapter> {
 

--- a/core/data/api/src/main/kotlin/voice/core/data/repo/ChapterRepo.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/repo/ChapterRepo.kt
@@ -13,10 +13,11 @@ public interface ChapterRepo {
 public suspend inline fun ChapterRepo.getOrPut(
   id: ChapterId,
   lastModified: Instant,
+  fileSize: Long,
   defaultValue: () -> Chapter?,
 ): Chapter? {
   val chapter = get(id)
-  if (chapter != null && chapter.fileLastModified == lastModified) {
+  if (chapter != null && chapter.fileLastModified == lastModified && chapter.fileSize == fileSize) {
     return chapter
   }
   return defaultValue()?.also { put(it) }

--- a/core/data/api/src/test/kotlin/voice/core/data/BookFactory.kt
+++ b/core/data/api/src/test/kotlin/voice/core/data/BookFactory.kt
@@ -45,5 +45,6 @@ fun chapter(
     duration = duration,
     fileLastModified = Instant.EPOCH,
     markData = emptyList(),
+    fileSize = 0,
   )
 }

--- a/core/data/api/src/test/kotlin/voice/core/data/ChapterTest.kt
+++ b/core/data/api/src/test/kotlin/voice/core/data/ChapterTest.kt
@@ -150,6 +150,7 @@ class ChapterTest {
       id = ChapterId(""),
       markData = marks,
       name = "Chapter",
+      fileSize = 0,
     ).chapterMarks.map { MarkPosition(it.startMs, it.endMs) }
 
     val expectedPositions = coverageToPositions(expectedCoverage)

--- a/core/data/impl/schemas/voice.core.data.repo.internals.AppDb/59.json
+++ b/core/data/impl/schemas/voice.core.data.repo.internals.AppDb/59.json
@@ -1,0 +1,314 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 59,
+    "identityHash": "3a02ecf5407cd6543f00f62df2f35c86",
+    "entities": [
+      {
+        "tableName": "chapters2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `duration` INTEGER NOT NULL, `fileLastModified` TEXT NOT NULL, `fileSize` INTEGER NOT NULL DEFAULT 0, `markData` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileLastModified",
+            "columnName": "fileLastModified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "markData",
+            "columnName": "markData",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "content2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playbackSpeed` REAL NOT NULL, `skipSilence` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastPlayedAt` TEXT NOT NULL, `author` TEXT, `name` TEXT NOT NULL, `addedAt` TEXT NOT NULL, `chapters` TEXT NOT NULL, `currentChapter` TEXT NOT NULL, `positionInChapter` INTEGER NOT NULL, `cover` TEXT, `gain` REAL NOT NULL DEFAULT 0, `genre` TEXT, `narrator` TEXT, `series` TEXT, `part` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipSilence",
+            "columnName": "skipSilence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentChapter",
+            "columnName": "currentChapter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionInChapter",
+            "columnName": "positionInChapter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gain",
+            "columnName": "gain",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "series",
+            "columnName": "series",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "part",
+            "columnName": "part",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmark2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `title` TEXT, `time` INTEGER NOT NULL, `addedAt` TEXT NOT NULL, `setBySleepTimer` INTEGER NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setBySleepTimer",
+            "columnName": "setBySleepTimer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookSearchFts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, `author` TEXT, `genre` TEXT, `narrator` TEXT, `series` TEXT, `part` TEXT, `id` TEXT NOT NULL, `isActive` INTEGER NOT NULL, tokenize=unicode61, content=`content2`, notindexed=`id`, notindexed=`isActive`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "series",
+            "columnName": "series",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "part",
+            "columnName": "part",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "content2",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [
+            "id",
+            "isActive"
+          ],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_bookSearchFts_BEFORE_UPDATE BEFORE UPDATE ON `content2` BEGIN DELETE FROM `bookSearchFts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_bookSearchFts_BEFORE_DELETE BEFORE DELETE ON `content2` BEGIN DELETE FROM `bookSearchFts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_bookSearchFts_AFTER_UPDATE AFTER UPDATE ON `content2` BEGIN INSERT INTO `bookSearchFts`(`docid`, `name`, `author`, `genre`, `narrator`, `series`, `part`, `id`, `isActive`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`author`, NEW.`genre`, NEW.`narrator`, NEW.`series`, NEW.`part`, NEW.`id`, NEW.`isActive`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_bookSearchFts_AFTER_INSERT AFTER INSERT ON `content2` BEGIN INSERT INTO `bookSearchFts`(`docid`, `name`, `author`, `genre`, `narrator`, `series`, `part`, `id`, `isActive`) VALUES (NEW.`rowid`, NEW.`name`, NEW.`author`, NEW.`genre`, NEW.`narrator`, NEW.`series`, NEW.`part`, NEW.`id`, NEW.`isActive`); END"
+        ]
+      },
+      {
+        "tableName": "recentBookSearch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`searchTerm` TEXT NOT NULL, PRIMARY KEY(`searchTerm`))",
+        "fields": [
+          {
+            "fieldPath": "searchTerm",
+            "columnName": "searchTerm",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "searchTerm"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3a02ecf5407cd6543f00f62df2f35c86')"
+    ]
+  }
+}

--- a/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/AppDb.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/AppDb.kt
@@ -31,6 +31,7 @@ import voice.core.data.repo.internals.migrations.Migration56
     AutoMigration(from = 55, to = 56),
     AutoMigration(from = 56, to = 57, spec = Migration56::class),
     AutoMigration(from = 57, to = 58),
+    AutoMigration(from = 58, to = 59),
   ],
 )
 @TypeConverters(Converters::class)
@@ -43,7 +44,7 @@ public abstract class AppDb : RoomDatabase() {
   public abstract fun recentBookSearchDao(): RecentBookSearchDao
 
   internal companion object {
-    const val VERSION = 58
+    const val VERSION = 59
     const val DATABASE_NAME = "autoBookDB"
   }
 }

--- a/core/playback/src/test/kotlin/voice/core/playback/CurrentBookResolverTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/CurrentBookResolverTest.kt
@@ -22,6 +22,7 @@ class CurrentBookResolverTest {
         duration = 10_000,
         fileLastModified = Instant.EPOCH,
         markData = emptyList(),
+        fileSize = 0,
       ),
       Chapter(
         id = ChapterId("chapter-2"),
@@ -29,6 +30,7 @@ class CurrentBookResolverTest {
         duration = 10_000,
         fileLastModified = Instant.EPOCH,
         markData = emptyList(),
+        fileSize = 0,
       ),
     ),
   )

--- a/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
@@ -326,6 +326,7 @@ class VoicePlayerTest {
       markData = marks.map {
         MarkData(it.startMs, it.name ?: "mark ")
       },
+      fileSize = 0,
     )
   }
 

--- a/core/playback/src/test/kotlin/voice/core/playback/session/search/BookSearchHandlerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/session/search/BookSearchHandlerTest.kt
@@ -135,6 +135,7 @@ private fun chapter(): Chapter {
     duration = 10000,
     fileLastModified = Instant.EPOCH,
     markData = emptyList(),
+    fileSize = 0,
   )
 }
 

--- a/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/ChapterParser.kt
@@ -27,7 +27,11 @@ internal class ChapterParser(
     suspend fun parseChapters(file: CachedDocumentFile) {
       if (file.isAudioFile()) {
         val id = ChapterId(file.uri)
-        val chapter = chapterRepo.getOrPut(id, Instant.ofEpochMilli(file.lastModified)) {
+        val chapter = chapterRepo.getOrPut(
+          id = id,
+          lastModified = Instant.ofEpochMilli(file.lastModified),
+          fileSize = file.length,
+        ) {
           val metaData = mediaAnalyzer.analyze(file) ?: return@getOrPut null
           analyzedMetadata[id] = metaData
           Chapter(
@@ -36,6 +40,7 @@ internal class ChapterParser(
             fileLastModified = Instant.ofEpochMilli(file.lastModified),
             name = metaData.title ?: metaData.fileName,
             markData = metaData.chapters,
+            fileSize = file.length,
           )
         }
         if (chapter != null) {

--- a/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
+++ b/core/scanner/src/test/kotlin/voice/core/scanner/BookParserTest.kt
@@ -117,6 +117,7 @@ class BookParserTest {
     duration = 1000L,
     fileLastModified = Instant.EPOCH,
     markData = emptyList(),
+    fileSize = 0,
   )
 
   private fun metadata(

--- a/core/search/src/test/kotlin/voice/core/search/BookFactory.kt
+++ b/core/search/src/test/kotlin/voice/core/search/BookFactory.kt
@@ -53,5 +53,6 @@ fun chapter(
     duration = duration,
     fileLastModified = Instant.EPOCH,
     markData = emptyList(),
+    fileSize = 0,
   )
 }

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/BookFactory.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/BookFactory.kt
@@ -49,5 +49,6 @@ fun chapter(
     duration = duration,
     fileLastModified = Instant.EPOCH,
     markData = emptyList(),
+    fileSize = 0,
   )
 }

--- a/features/playbackScreen/src/test/kotlin/voice/features/playbackScreen/BookPlayViewModelTest.kt
+++ b/features/playbackScreen/src/test/kotlin/voice/features/playbackScreen/BookPlayViewModelTest.kt
@@ -381,5 +381,6 @@ private fun chapter(): Chapter {
       MarkData(startMs = 4.minutes.inWholeMilliseconds, name = "Final Section"),
     ),
     name = "name",
+    fileSize = 0,
   )
 }


### PR DESCRIPTION
Until now, only the last modified stamp of a file was used to determine if a specific file should be parsed again.

Now, we also use the size of the file as a cache key.

There are still cases where this could miss (i.e. if one changes a single character of a metadata), but generally this should lead to changes more reliably being picked up.