### PR TITLE
fix album cover cropping when chapters are displayed

### DIFF
--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayAppBar.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayAppBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -83,7 +84,7 @@ internal fun BookPlayAppBar(
       },
     )
   } else {
-    LargeTopAppBar(
+    MediumTopAppBar(
       navigationIcon = {
         CloseIcon(onCloseClick)
       },

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/Cover.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/Cover.kt
@@ -35,7 +35,7 @@ internal fun Cover(
         )
       }
       .clip(RoundedCornerShape(20.dp)),
-    contentScale = ContentScale.Crop,
+    contentScale = ContentScale.Fit,
     model = cover,
     placeholder = painterResource(id = UiR.drawable.album_art),
     error = painterResource(id = UiR.drawable.album_art),


### PR DESCRIPTION
improve the playback screen layout when chapters are available.

When chapter navigation is visible, the layout reduced the available height for the cover, causing it to be center cropped and parts of the artwork to be cut off.

ContentScale.Fit for cover artwork rendering in fixed aspect ratio
MediumTopAppBar for the tiltle name as so it dont take lot of space in playback screen.

The cover artwork remains square and is no longer cropped differently when chapter navigation is shown even when chapters takes 3 lines and Title name looks fine.