### PR TITLE
Show current chapter in the media notification when the audiobook is a single file with Marks

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/LivePlaybackState.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/LivePlaybackState.kt
@@ -5,6 +5,7 @@ import androidx.media3.session.MediaController
 import voice.core.data.Book
 import voice.core.data.BookId
 import voice.core.data.ChapterId
+import voice.core.playback.session.EXTRA_MARK_START_MS
 import voice.core.playback.session.MediaId
 import voice.core.playback.session.toMediaIdOrNull
 
@@ -17,15 +18,20 @@ data class LivePlaybackState(
 )
 
 internal fun MediaController.livePlaybackStateSnapshot(bookId: BookId? = null): LivePlaybackState? {
-  val mediaId = currentMediaItem?.mediaId?.toMediaIdOrNull() as? MediaId.Chapter ?: return null
+  val currentItem = currentMediaItem ?: return null
+  val mediaId = currentItem.mediaId.toMediaIdOrNull() as? MediaId.Chapter ?: return null
   if (bookId != null && mediaId.bookId != bookId) {
     return null
   }
   val positionMs = currentPosition.takeUnless { it == C.TIME_UNSET || it < 0 } ?: return null
+  // The MediaSession exposes mark-relative positions for the notification seek bar.
+  // Translate back to file-relative for in-app state, using the markStartMs we encode
+  // in the current MediaItem's metadata extras.
+  val markStartMs = currentItem.mediaMetadata.extras?.getLong(EXTRA_MARK_START_MS, 0L) ?: 0L
   return LivePlaybackState(
     bookId = mediaId.bookId,
     chapterId = mediaId.chapterId,
-    positionMs = positionMs,
+    positionMs = positionMs + markStartMs,
     isPlaying = isPlaying,
     playbackSpeed = playbackParameters.speed,
   )

--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -23,8 +23,8 @@ import voice.core.featureflag.Media3AudioOffloadFeatureFlagQualifier
 import voice.core.playback.misc.VolumeGain
 import voice.core.playback.notification.MainActivityIntentProvider
 import voice.core.playback.player.DurationInconsistenciesUpdater
+import voice.core.playback.player.MarkAwarePlayer
 import voice.core.playback.player.OnlyAudioRenderersFactory
-import voice.core.playback.player.VoicePlayer
 import voice.core.playback.player.onAudioSessionIdChanged
 import voice.core.playback.playstate.PlayStateDelegatingListener
 import voice.core.playback.playstate.PositionUpdater
@@ -96,7 +96,7 @@ interface PlaybackModule {
   @SingleIn(PlaybackScope::class)
   fun session(
     service: PlaybackService,
-    player: VoicePlayer,
+    player: MarkAwarePlayer,
     callback: LibrarySessionCallback,
     mainActivityIntentProvider: MainActivityIntentProvider,
     context: Context,

--- a/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
@@ -185,10 +185,11 @@ class MarkAwarePlayer(
     val mark = currentMark()
     if (mark == null) {
       super.seekTo(positionMs)
-    } else {
-      val markDuration = mark.endMs - mark.startMs + 1
-      val clamped = positionMs.coerceIn(0L, markDuration)
-      super.seekTo(mark.startMs + clamped)
+      return
     }
+
+    val maxOffset = (mark.endMs - mark.startMs).coerceAtLeast(0L)
+    val clamped = positionMs.coerceIn(0L, maxOffset)
+    super.seekTo(mark.startMs + clamped)
   }
 }

--- a/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
@@ -8,6 +8,8 @@ import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import voice.core.data.Book
@@ -42,6 +44,7 @@ class MarkAwarePlayer(
 
   private var currentBook: Book? = null
   private var markTickJob: Job? = null
+  private var bookObserverJob: Job? = null
 
   init {
     voicePlayer.addListener(
@@ -66,21 +69,36 @@ class MarkAwarePlayer(
         }
       },
     )
+
+    // Apply translation immediately when the wrapper is created in case the underlying
+    // player is already prepared/playing (e.g., service was recreated mid-playback).
+    syncCurrentBook(voicePlayer.currentMediaItem)
+    if (voicePlayer.isPlaying) startMarkTicking()
   }
 
   private fun syncCurrentBook(mediaItem: MediaItem?) {
     val bookId = (mediaItem?.mediaId?.toMediaIdOrNull() as? MediaId.Chapter)?.bookId
     if (bookId == null) {
       currentBook = null
+      bookObserverJob?.cancel()
+      bookObserverJob = null
       return
     }
     if (currentBook?.id == bookId) {
       maybeReplaceMediaItemForMark()
       return
     }
-    scope.launch {
-      currentBook = repo.get(bookId)
-      maybeReplaceMediaItemForMark()
+    bookObserverJob?.cancel()
+    bookObserverJob = scope.launch {
+      repo.flow(bookId)
+        .filterNotNull()
+        .distinctUntilChangedBy { it.content.name to it.content.cover }
+        .collect { book ->
+          currentBook = book
+          // Force the current MediaItem to be rebuilt so renames / cover changes propagate
+          // to the notification, even when the active mark hasn't moved.
+          maybeReplaceMediaItemForMark(force = true)
+        }
     }
   }
 
@@ -97,17 +115,19 @@ class MarkAwarePlayer(
     return chapter.markForPosition(rawPos)
   }
 
-  private fun maybeReplaceMediaItemForMark() {
+  private fun maybeReplaceMediaItemForMark(force: Boolean = false) {
     val book = currentBook ?: return
     val chapter = currentChapter() ?: return
     val mark = currentMark() ?: return
     val index = voicePlayer.currentMediaItemIndex
     if (index < 0 || index >= voicePlayer.mediaItemCount) return
-    val current = voicePlayer.getMediaItemAt(index)
-    val currentMarkStart = current.mediaMetadata.extras
-      ?.getLong(EXTRA_MARK_START_MS, Long.MIN_VALUE)
-      ?: Long.MIN_VALUE
-    if (currentMarkStart == mark.startMs) return
+    if (!force) {
+      val current = voicePlayer.getMediaItemAt(index)
+      val currentMarkStart = current.mediaMetadata.extras
+        ?.getLong(EXTRA_MARK_START_MS, Long.MIN_VALUE)
+        ?: Long.MIN_VALUE
+      if (currentMarkStart == mark.startMs) return
+    }
     voicePlayer.replaceMediaItem(index, mediaItemProvider.mediaItemForMark(chapter, mark, book.content))
   }
 
@@ -126,6 +146,16 @@ class MarkAwarePlayer(
     markTickJob = null
   }
 
+  /**
+   * Cancel any long-running observers/tickers started by this wrapper. Safe to call multiple
+   * times. Mainly useful when the owning scope is not torn down (e.g. in tests).
+   */
+  fun releaseObservers() {
+    bookObserverJob?.cancel()
+    bookObserverJob = null
+    stopMarkTicking()
+  }
+
   override fun getDuration(): Long {
     val mark = currentMark() ?: return super.getDuration()
     return mark.endMs - mark.startMs + 1
@@ -137,7 +167,8 @@ class MarkAwarePlayer(
     val pos = super.getCurrentPosition()
     val mark = currentMark() ?: return pos
     if (pos == C.TIME_UNSET) return pos
-    return (pos - mark.startMs).coerceAtLeast(0L)
+    val markDuration = mark.endMs - mark.startMs + 1
+    return (pos - mark.startMs).coerceIn(0L, markDuration)
   }
 
   override fun getContentPosition(): Long = currentPosition
@@ -146,7 +177,8 @@ class MarkAwarePlayer(
     val buf = super.getBufferedPosition()
     val mark = currentMark() ?: return buf
     if (buf == C.TIME_UNSET) return buf
-    return (buf - mark.startMs).coerceAtLeast(0L)
+    val markDuration = mark.endMs - mark.startMs + 1
+    return (buf - mark.startMs).coerceIn(0L, markDuration)
   }
 
   override fun seekTo(positionMs: Long) {
@@ -154,7 +186,9 @@ class MarkAwarePlayer(
     if (mark == null) {
       super.seekTo(positionMs)
     } else {
-      super.seekTo(mark.startMs + positionMs.coerceAtLeast(0L))
+      val markDuration = mark.endMs - mark.startMs + 1
+      val clamped = positionMs.coerceIn(0L, markDuration)
+      super.seekTo(mark.startMs + clamped)
     }
   }
 }

--- a/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/MarkAwarePlayer.kt
@@ -1,0 +1,160 @@
+package voice.core.playback.player
+
+import androidx.media3.common.C
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import voice.core.data.Book
+import voice.core.data.Chapter
+import voice.core.data.ChapterMark
+import voice.core.data.markForPosition
+import voice.core.data.repo.BookRepository
+import voice.core.playback.session.EXTRA_MARK_START_MS
+import voice.core.playback.session.MediaId
+import voice.core.playback.session.MediaItemProvider
+import voice.core.playback.session.toMediaIdOrNull
+
+/**
+ * ForwardingPlayer placed between [VoicePlayer] and the [androidx.media3.session.MediaLibrarySession].
+ *
+ * Translates the position/duration that the session (and therefore the Android media notification
+ * seek bar plus any [androidx.media3.session.MediaController]) sees so that they reflect the
+ * current [ChapterMark] rather than the whole audio file. It also keeps the current
+ * [MediaItem]'s metadata title in sync with the active mark so the notification shows the mark
+ * name when present, falling back to the chapter name and finally to the book name.
+ *
+ * The actual audio playback is unchanged: the wrapped [VoicePlayer] (and the underlying ExoPlayer)
+ * keep operating on file-relative positions.
+ */
+@Inject
+class MarkAwarePlayer(
+  private val voicePlayer: VoicePlayer,
+  private val mediaItemProvider: MediaItemProvider,
+  private val repo: BookRepository,
+  private val scope: CoroutineScope,
+) : ForwardingPlayer(voicePlayer) {
+
+  private var currentBook: Book? = null
+  private var markTickJob: Job? = null
+
+  init {
+    voicePlayer.addListener(
+      object : Player.Listener {
+        override fun onMediaItemTransition(
+          mediaItem: MediaItem?,
+          reason: Int,
+        ) {
+          syncCurrentBook(mediaItem)
+        }
+
+        override fun onPositionDiscontinuity(
+          oldPosition: Player.PositionInfo,
+          newPosition: Player.PositionInfo,
+          reason: Int,
+        ) {
+          maybeReplaceMediaItemForMark()
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+          if (isPlaying) startMarkTicking() else stopMarkTicking()
+        }
+      },
+    )
+  }
+
+  private fun syncCurrentBook(mediaItem: MediaItem?) {
+    val bookId = (mediaItem?.mediaId?.toMediaIdOrNull() as? MediaId.Chapter)?.bookId
+    if (bookId == null) {
+      currentBook = null
+      return
+    }
+    if (currentBook?.id == bookId) {
+      maybeReplaceMediaItemForMark()
+      return
+    }
+    scope.launch {
+      currentBook = repo.get(bookId)
+      maybeReplaceMediaItemForMark()
+    }
+  }
+
+  private fun currentChapter(): Chapter? {
+    val book = currentBook ?: return null
+    val mediaId = voicePlayer.currentMediaItem?.mediaId?.toMediaIdOrNull() as? MediaId.Chapter
+      ?: return null
+    return book.chapters.firstOrNull { it.id == mediaId.chapterId }
+  }
+
+  private fun currentMark(): ChapterMark? {
+    val chapter = currentChapter() ?: return null
+    val rawPos = voicePlayer.currentPosition.takeUnless { it == C.TIME_UNSET } ?: 0L
+    return chapter.markForPosition(rawPos)
+  }
+
+  private fun maybeReplaceMediaItemForMark() {
+    val book = currentBook ?: return
+    val chapter = currentChapter() ?: return
+    val mark = currentMark() ?: return
+    val index = voicePlayer.currentMediaItemIndex
+    if (index < 0 || index >= voicePlayer.mediaItemCount) return
+    val current = voicePlayer.getMediaItemAt(index)
+    val currentMarkStart = current.mediaMetadata.extras
+      ?.getLong(EXTRA_MARK_START_MS, Long.MIN_VALUE)
+      ?: Long.MIN_VALUE
+    if (currentMarkStart == mark.startMs) return
+    voicePlayer.replaceMediaItem(index, mediaItemProvider.mediaItemForMark(chapter, mark, book.content))
+  }
+
+  private fun startMarkTicking() {
+    if (markTickJob?.isActive == true) return
+    markTickJob = scope.launch {
+      while (isActive) {
+        delay(250)
+        maybeReplaceMediaItemForMark()
+      }
+    }
+  }
+
+  private fun stopMarkTicking() {
+    markTickJob?.cancel()
+    markTickJob = null
+  }
+
+  override fun getDuration(): Long {
+    val mark = currentMark() ?: return super.getDuration()
+    return mark.endMs - mark.startMs + 1
+  }
+
+  override fun getContentDuration(): Long = duration
+
+  override fun getCurrentPosition(): Long {
+    val pos = super.getCurrentPosition()
+    val mark = currentMark() ?: return pos
+    if (pos == C.TIME_UNSET) return pos
+    return (pos - mark.startMs).coerceAtLeast(0L)
+  }
+
+  override fun getContentPosition(): Long = currentPosition
+
+  override fun getBufferedPosition(): Long {
+    val buf = super.getBufferedPosition()
+    val mark = currentMark() ?: return buf
+    if (buf == C.TIME_UNSET) return buf
+    return (buf - mark.startMs).coerceAtLeast(0L)
+  }
+
+  override fun seekTo(positionMs: Long) {
+    val mark = currentMark()
+    if (mark == null) {
+      super.seekTo(positionMs)
+    } else {
+      super.seekTo(mark.startMs + positionMs.coerceAtLeast(0L))
+    }
+  }
+}

--- a/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
@@ -10,6 +10,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.PlayerMessage
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -52,6 +55,8 @@ class VoicePlayer(
   private val sleepTimer: SleepTimer,
   private val analytics: Analytics,
 ) : ForwardingPlayer(player) {
+
+  private var bookMetadataJob: Job? = null
 
   fun forceSeekToNext() {
     scope.launch {
@@ -296,10 +301,29 @@ class VoicePlayer(
             book.content.positionInChapter,
           )
           registerChapterMarkCallbacks(book.chapters)
+          observeBookMetadata(mediaId.id)
         }
       } else {
         Logger.w("Unexpected mediaId=$mediaId")
       }
+    }
+  }
+
+  private fun observeBookMetadata(bookId: BookId) {
+    bookMetadataJob?.cancel()
+    bookMetadataJob = scope.launch {
+      repo.flow(bookId)
+        .filterNotNull()
+        .distinctUntilChangedBy { book -> book.content.name to book.content.cover }
+        .collect { book ->
+          val itemCount = player.mediaItemCount
+          val chapters = mediaItemProvider.chapters(book)
+          chapters.forEachIndexed { index, newItem ->
+            if (index < itemCount) {
+              player.replaceMediaItem(index, newItem)
+            }
+          }
+        }
     }
   }
 

--- a/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemBuilder.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemBuilder.kt
@@ -1,6 +1,7 @@
 package voice.core.playback.session
 
 import android.net.Uri
+import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import kotlinx.serialization.SerializationException
@@ -23,6 +24,7 @@ internal fun MediaItem(
   sourceUri: Uri? = null,
   imageUri: Uri? = null,
   mediaType: MediaType,
+  extras: Bundle? = null,
 ): MediaItem {
   val metadata =
     MediaMetadata.Builder()
@@ -40,6 +42,7 @@ internal fun MediaItem(
           MediaType.AudioBookRoot -> MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS
         },
       )
+      .setExtras(extras)
       .build()
 
   return MediaItem.Builder()

--- a/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
@@ -2,6 +2,7 @@ package voice.core.playback.session
 
 import android.app.Application
 import android.net.Uri
+import android.os.Bundle
 import androidx.datastore.core.DataStore
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -14,6 +15,7 @@ import voice.core.data.BookComparator
 import voice.core.data.BookContent
 import voice.core.data.BookId
 import voice.core.data.Chapter
+import voice.core.data.ChapterMark
 import voice.core.data.repo.BookContentRepo
 import voice.core.data.repo.BookRepository
 import voice.core.data.repo.ChapterRepo
@@ -140,8 +142,32 @@ class MediaItemProvider(
     sourceUri = chapter.id.toUri(),
     imageUri = content.cover?.toProvidedUri(),
     artist = content.author,
+    album = content.name,
     mediaType = MediaType.AudioBookChapter,
   )
 
+  internal fun mediaItemForMark(
+    chapter: Chapter,
+    mark: ChapterMark,
+    content: BookContent,
+  ): MediaItem {
+    val title = mark.name ?: chapter.name ?: content.name
+    val extras = Bundle().apply { putLong(EXTRA_MARK_START_MS, mark.startMs) }
+    return MediaItem(
+      title = title,
+      mediaId = MediaId.Chapter(bookId = content.id, chapterId = chapter.id),
+      browsable = false,
+      isPlayable = true,
+      sourceUri = chapter.id.toUri(),
+      imageUri = content.cover?.toProvidedUri(),
+      artist = content.author,
+      album = content.name,
+      mediaType = MediaType.AudioBookChapter,
+      extras = extras,
+    )
+  }
+
   private fun File.toProvidedUri(): Uri = imageFileProvider.uri(this)
 }
+
+internal const val EXTRA_MARK_START_MS = "voice.markStartMs"

--- a/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
@@ -34,15 +34,11 @@ import voice.core.data.repo.BookRepository
 import voice.core.playback.session.EXTRA_MARK_START_MS
 import voice.core.playback.session.MediaId
 import voice.core.playback.session.MediaItemProvider
-import voice.core.playback.session.MediaType
-import voice.core.playback.session.toMediaIdOrNull
 import java.time.Instant
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.Uuid
 

--- a/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
@@ -1,0 +1,499 @@
+package voice.core.playback.player
+
+import android.os.Bundle
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import voice.core.data.Book
+import voice.core.data.BookContent
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.ChapterMark
+import voice.core.data.MarkData
+import voice.core.data.repo.BookRepository
+import voice.core.playback.session.EXTRA_MARK_START_MS
+import voice.core.playback.session.MediaId
+import voice.core.playback.session.MediaItemProvider
+import voice.core.playback.session.MediaType
+import voice.core.playback.session.toMediaIdOrNull
+import java.time.Instant
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.Uuid
+
+@RunWith(AndroidJUnit4::class)
+class MarkAwarePlayerTest {
+
+  private val scope = TestScope()
+  private val bookId = BookId(Uuid.random().toString())
+  private lateinit var currentBook: Book
+
+  private val repoFlow = MutableStateFlow<Book?>(null)
+  private val repo = mockk<BookRepository> {
+    coEvery { get(bookId) } answers { currentBook }
+    coEvery { updateBook(any(), any()) } just Runs
+    every { flow(any()) } answers { repoFlow.filterNotNull() }
+  }
+
+  private val mediaItemProvider = mockk<MediaItemProvider>()
+
+  // Mock player states
+  private var currentPositionMock = 0L
+  private var durationMock = 10_000L
+  private var bufferedPositionMock = 0L
+  private var isPlayingMock = false
+  private var currentMediaItemMock: MediaItem? = null
+  private val listeners = mutableListOf<Player.Listener>()
+
+  private val voicePlayer = mockk<VoicePlayer>(relaxed = true) {
+    every { currentMediaItemIndex } returns 0
+    every { mediaItemCount } returns 1
+    every { currentMediaItem } answers { currentMediaItemMock }
+    every { currentPosition } answers { currentPositionMock }
+    every { duration } answers { durationMock }
+    every { bufferedPosition } answers { bufferedPositionMock }
+    every { isPlaying } answers { isPlayingMock }
+    every { getMediaItemAt(0) } answers { currentMediaItemMock ?: mockk(relaxed = true) }
+    every { addListener(any()) } answers {
+      listeners.add(arg(0))
+    }
+  }
+
+  private lateinit var markAware: MarkAwarePlayer
+
+  @BeforeTest
+  fun setUp() {
+    listeners.clear()
+    currentPositionMock = 0L
+    durationMock = 10_000L
+    bufferedPositionMock = 0L
+    isPlayingMock = false
+    currentMediaItemMock = null
+
+    // By default mock MediaItemProvider behavior
+    every { mediaItemProvider.mediaItemForMark(any(), any(), any()) } answers {
+      val chapter = arg<Chapter>(0)
+      val mark = arg<ChapterMark>(1)
+      val content = arg<BookContent>(2)
+      createTestMediaItem(
+        title = mark.name ?: chapter.name ?: content.name,
+        mediaId = MediaId.Chapter(bookId = content.id, chapterId = chapter.id),
+        album = content.name,
+        extras = Bundle().apply { putLong(EXTRA_MARK_START_MS, mark.startMs) }
+      )
+    }
+
+    markAware = MarkAwarePlayer(
+      voicePlayer = voicePlayer,
+      mediaItemProvider = mediaItemProvider,
+      repo = repo,
+      scope = scope,
+    )
+  }
+
+  @AfterTest
+  fun tearDown() {
+    markAware.releaseObservers()
+    scope.coroutineContext[Job]?.cancelChildren()
+  }
+
+  @Test
+  fun `currentPosition is mark-relative`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = null),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = null),
+        ),
+      ),
+    )
+
+    // Position inside second mark (5000..9999) -> mark-relative should be 2000
+    currentPositionMock = 7_000L
+    assertEquals(expected = 2_000L, actual = markAware.currentPosition)
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `duration returns current mark duration`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = null),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = null),
+        ),
+      ),
+    )
+
+    // Inside first mark (0..4999) -> duration is 5000
+    currentPositionMock = 1_000L
+    assertEquals(expected = 5_000L, actual = markAware.duration)
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `seekTo translates mark-relative to file-relative`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = null),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = null),
+        ),
+      ),
+    )
+
+    // Currently inside second mark (startMs = 5000)
+    currentPositionMock = 6_000L
+
+    // Seek to 2000 relative -> should seek to 7000 absolute
+    markAware.seekTo(2_000L)
+    verify { voicePlayer.seekTo(7_000L) }
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `seekTo clamps mark-relative position to mark duration`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = null),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = null),
+        ),
+      ),
+    )
+
+    // Currently inside second mark (startMs = 5000, duration = 4999)
+    currentPositionMock = 6_000L
+
+    // Seek to out-of-bounds 99_999 -> should clamp to mark duration (4999) -> seek to 9999
+    markAware.seekTo(99_999L)
+    verify { voicePlayer.seekTo(9_999L) }
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `current MediaItem carries markStartMs in metadata extras`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = null),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = null),
+        ),
+      ),
+    )
+
+    // Trigger position discontinuity to the second mark
+    currentPositionMock = 6_000L
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+    triggerPositionDiscontinuity()
+
+    verify {
+      voicePlayer.replaceMediaItem(0, any())
+    }
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `title uses mark name when present`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapterWithName(
+          name = "Chapter 1",
+          marks = arrayOf(
+            ChapterMark(startMs = 0, endMs = 4_999, name = "Intro"),
+            ChapterMark(startMs = 5_000, endMs = 9_999, name = "Climax"),
+          ),
+        ),
+      ),
+    )
+
+    currentPositionMock = 6_000L
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+    triggerPositionDiscontinuity()
+
+    // Assert it replaces the item with the correct title
+    val slot = slot<MediaItem>()
+    verify { voicePlayer.replaceMediaItem(0, capture(slot)) }
+    assertEquals(expected = "Climax", actual = slot.captured.mediaMetadata.title?.toString())
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `title falls back to book name when chapter and mark names are null`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapterWithName(
+          name = null,
+          marks = emptyArray(),
+        ),
+      ),
+    )
+
+    currentPositionMock = 1L
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+    triggerPositionDiscontinuity()
+
+    val slot = slot<MediaItem>()
+    verify { voicePlayer.replaceMediaItem(0, capture(slot)) }
+    assertEquals(expected = currentBook.content.name, actual = slot.captured.mediaMetadata.title?.toString())
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `book rename updates current MediaItem album`() = scope.runTest {
+    setMediaItems(
+      listOf(chapter(ChapterMark(startMs = 0, endMs = 9_999, name = null))),
+    )
+
+    val renamed = currentBook.update { it.copy(name = "Renamed Book") }
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+    repoFlow.value = renamed
+    runCurrent()
+
+    val slot = slot<MediaItem>()
+    verify(atLeast = 1) { voicePlayer.replaceMediaItem(0, capture(slot)) }
+    assertEquals(expected = "Renamed Book", actual = slot.captured.mediaMetadata.albumTitle?.toString())
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `returns direct values when current mark is null`() = scope.runTest {
+    // No book is set, so mark is null
+    assertEquals(expected = voicePlayer.duration, actual = markAware.duration)
+    assertEquals(expected = voicePlayer.currentPosition, actual = markAware.currentPosition)
+    assertEquals(expected = voicePlayer.bufferedPosition, actual = markAware.bufferedPosition)
+
+    markAware.seekTo(1234L)
+    verify { voicePlayer.seekTo(1234L) }
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `handles C TIME_UNSET position and buffer when mark is active`() = scope.runTest {
+    setMediaItems(
+      listOf(chapter(ChapterMark(startMs = 5_000, endMs = 9_999, name = null))),
+    )
+
+    currentPositionMock = C.TIME_UNSET
+    assertEquals(expected = C.TIME_UNSET, actual = markAware.currentPosition)
+
+    bufferedPositionMock = C.TIME_UNSET
+    assertEquals(expected = C.TIME_UNSET, actual = markAware.bufferedPosition)
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `syncCurrentBook handles transition to null mediaItem`() = scope.runTest {
+    setMediaItems(
+      listOf(chapter(ChapterMark(startMs = 0, endMs = 9_999, name = null))),
+    )
+
+    // Transition to a null / non-chapter media item
+    triggerMediaItemTransition(null)
+
+    // Since currentBook is null, duration should fall back to voicePlayer.duration
+    assertEquals(expected = voicePlayer.duration, actual = markAware.duration)
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `ticking periodically replaces media item when playing`() = scope.runTest {
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = "First"),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = "Second"),
+        ),
+      ),
+    )
+
+    isPlayingMock = true
+    triggerIsPlayingChanged(true)
+    runCurrent()
+
+    // Move to next mark position
+    currentPositionMock = 6_000L
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+
+    // Advance time to let ticker run
+    advanceTimeBy(300.milliseconds)
+    runCurrent()
+
+    verify {
+      voicePlayer.replaceMediaItem(0, any())
+    }
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `immediate ticking starting when player is already playing on creation`() = scope.runTest {
+    isPlayingMock = true
+    currentPositionMock = 6_000L
+
+    setMediaItems(
+      listOf(
+        chapter(
+          ChapterMark(startMs = 0, endMs = 4_999, name = "First"),
+          ChapterMark(startMs = 5_000, endMs = 9_999, name = "Second"),
+        ),
+      ),
+    )
+
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+    val newMarkAware = MarkAwarePlayer(
+      voicePlayer = voicePlayer,
+      mediaItemProvider = mediaItemProvider,
+      repo = repo,
+      scope = scope,
+    )
+    runCurrent()
+
+    advanceTimeBy(300.milliseconds)
+    runCurrent()
+
+    verify {
+      voicePlayer.replaceMediaItem(0, any())
+    }
+
+    newMarkAware.releaseObservers()
+    markAware.releaseObservers()
+  }
+
+  @Test
+  fun `releaseObservers stops all background jobs`() = scope.runTest {
+    setMediaItems(
+      listOf(chapter(ChapterMark(startMs = 0, endMs = 9_999, name = null))),
+    )
+
+    markAware.releaseObservers()
+    clearMocks(voicePlayer, answers = false, recordedCalls = true, childMocks = false)
+
+    val renamed = currentBook.update { it.copy(name = "Never Collected") }
+    repoFlow.value = renamed
+    runCurrent()
+
+    // Should not trigger replaceMediaItem after release
+    verify(exactly = 0) { voicePlayer.replaceMediaItem(any(), any()) }
+  }
+
+  private fun createTestMediaItem(
+    title: String,
+    mediaId: MediaId,
+    album: String? = null,
+    extras: Bundle? = null,
+  ): MediaItem {
+    val mediaIdString = kotlinx.serialization.json.Json.encodeToString(MediaId.serializer(), mediaId)
+    val metadata = androidx.media3.common.MediaMetadata.Builder()
+      .setTitle(title)
+      .setAlbumTitle(album)
+      .setExtras(extras)
+      .build()
+    return MediaItem.Builder()
+      .setMediaId(mediaIdString)
+      .setMediaMetadata(metadata)
+      .build()
+  }
+
+  private fun localBook(
+    chapters: List<Chapter>,
+    id: BookId = BookId(Uuid.random().toString()),
+    positionInChapter: Long = 0,
+  ): Book {
+    return Book(
+      content = BookContent(
+        author = Uuid.random().toString(),
+        name = Uuid.random().toString(),
+        positionInChapter = positionInChapter,
+        playbackSpeed = 1F,
+        addedAt = Instant.EPOCH,
+        chapters = chapters.map { it.id },
+        cover = null,
+        currentChapter = chapters.first().id,
+        isActive = true,
+        lastPlayedAt = Instant.EPOCH,
+        skipSilence = false,
+        id = id,
+        gain = 0F,
+        genre = null,
+        narrator = null,
+        series = null,
+        part = null,
+      ),
+      chapters = chapters,
+    )
+  }
+
+  private fun TestScope.setMediaItems(
+    chapters: List<Chapter>,
+  ) {
+    currentBook = localBook(chapters, bookId)
+    repoFlow.value = currentBook
+    val mediaItem = createTestMediaItem(
+      title = chapters.first().name ?: "chapter",
+      mediaId = MediaId.Chapter(bookId = bookId, chapterId = chapters.first().id)
+    )
+    currentMediaItemMock = mediaItem
+    triggerMediaItemTransition(mediaItem)
+    runCurrent()
+  }
+
+  private fun chapter(vararg marks: ChapterMark): Chapter = chapterWithName(name = "chapter", marks = marks)
+
+  private fun chapterWithName(
+    name: String?,
+    marks: Array<out ChapterMark>,
+  ): Chapter {
+    val duration = if (marks.isEmpty()) 9_999L else marks.maxOf { it.endMs }
+    return Chapter(
+      id = ChapterId(Uuid.random().toString()),
+      name = name,
+      duration = duration,
+      fileLastModified = Instant.EPOCH,
+      markData = marks.map { MarkData(it.startMs, it.name ?: "mark ") },
+      fileSize = 0,
+    )
+  }
+
+  private fun triggerMediaItemTransition(mediaItem: MediaItem?) {
+    listeners.forEach { it.onMediaItemTransition(mediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED) }
+  }
+
+  private fun triggerPositionDiscontinuity() {
+    listeners.forEach {
+      it.onPositionDiscontinuity(
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Player.DISCONTINUITY_REASON_SEEK,
+      )
+    }
+  }
+
+  private fun triggerIsPlayingChanged(isPlaying: Boolean) {
+    listeners.forEach { it.onIsPlayingChanged(isPlaying) }
+  }
+}

--- a/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/MarkAwarePlayerTest.kt
@@ -8,7 +8,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -464,7 +463,7 @@ class MarkAwarePlayerTest {
     name: String?,
     marks: Array<out ChapterMark>,
   ): Chapter {
-    val duration = if (marks.isEmpty()) 9_999L else marks.maxOf { it.endMs }
+    val duration = (marks.maxOfOrNull { it.endMs } ?: 9_999L) + 1
     return Chapter(
       id = ChapterId(Uuid.random().toString()),
       name = name,

--- a/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -91,6 +92,7 @@ class VoicePlayerTest {
     repo = mockk {
       coEvery { get(bookId) } answers { currentBook }
       coEvery { updateBook(any(), any()) } just Runs
+      every { flow(any()) } returns emptyFlow()
     },
     currentBookStoreId = mockk {
       every { data } returns flowOf(bookId)


### PR DESCRIPTION
## What

1. The Android media notification now reflects the current chapter mark when the audiobook is a single file:
- **Title**: `mark.name`
- **Seek bar**: spans drom the current mark to the next instead of the whole audiobook
- **Album**: send new metadata property with the renamed book name (this is added for both single file audiobooks with marks and multifile ones with chapters)

**Before and After**

https://github.com/user-attachments/assets/0d04b633-ee45-4b0b-be19-01c0a03660ee

https://github.com/user-attachments/assets/fc770524-ac9c-406e-8061-c5411d7b0901

2. When the user renames the book or
  changes its cover from the app, the running notification updates
  immediately. Previously the new name or cover only appeared after restarting
  playback.

**Before and After**

https://github.com/user-attachments/assets/f7c36fe2-dff0-4617-bc38-a90ac7f5a853

https://github.com/user-attachments/assets/feb5f6ca-c0a7-4351-94bd-647368ba2f85

## How

1. Added `MarkAwareNotificationPlayer`, a `ForwardingPlayer` that wraps
`VoicePlayer` and is the player handed to `MediaLibrarySession`. It:

- Overrides `getDuration` / `getCurrentPosition` / `getContentDuration` /
  `getContentPosition` / `getBufferedPosition` / `seekTo(Long)` to be
  mark-relative.
- Listens to media item transitions, position discontinuities, and a small
  tick while playing to detect mark crossings.
- `LivePlaybackState` reads `markStartMs` from the MediaItem's metadata
  extras to translate the controller's mark-relative position back to the
  file-relative position used in `BookContent.positionInChapter`.

2. `VoicePlayer.observeBookMetadata` collects the book flow from
  `BookRepository` while a book is active, and on `name`/`cover` changes
  rebuilds the queue's MediaItems via `replaceMediaItem`.