### PR TITLE
feat: Add group by author feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
   }
 
   defaultConfig {
-    applicationId = "de.ph1b.audiobook.test"
+    applicationId = "de.ph1b.audiobook"
     versionName = providers.gradleProperty("voice.versionName").orNull ?: "1.0.0"
     versionCode = providers.gradleProperty("voice.versionCode").orNull?.toInt() ?: Int.MAX_VALUE
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
   }
 
   defaultConfig {
-    applicationId = "de.ph1b.audiobook"
+    applicationId = "de.ph1b.audiobook.test"
     versionName = providers.gradleProperty("voice.versionName").orNull ?: "1.0.0"
     versionCode = providers.gradleProperty("voice.versionCode").orNull?.toInt() ?: Int.MAX_VALUE
 

--- a/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
@@ -49,3 +49,6 @@ public annotation class FeatureFlagOverridesStore
 
 @Qualifier
 public annotation class GroupByAuthorStore
+
+@Qualifier
+public annotation class ExpandedAuthorsStore

--- a/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
@@ -46,3 +46,6 @@ public annotation class DeveloperMenuUnlockedStore
 
 @Qualifier
 public annotation class FeatureFlagOverridesStore
+
+@Qualifier
+public annotation class GroupByAuthorStore

--- a/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
@@ -11,6 +11,7 @@ import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.SetSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import voice.core.data.BookId
@@ -210,6 +211,17 @@ public interface StoreModule {
   @GroupByAuthorStore
   private fun groupByAuthor(factory: VoiceDataStoreFactory): DataStore<Boolean> {
     return factory.boolean("groupByAuthor", defaultValue = false)
+  }
+
+  @Provides
+  @SingleIn(AppScope::class)
+  @ExpandedAuthorsStore
+  private fun expandedAuthors(factory: VoiceDataStoreFactory): DataStore<Set<String>> {
+    return factory.create(
+      serializer = SetSerializer(String.serializer()),
+      defaultValue = emptySet(),
+      fileName = "expandedAuthors",
+    )
   }
 }
 

--- a/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
@@ -204,6 +204,13 @@ public interface StoreModule {
       fileName = "featureFlagOverrides",
     )
   }
+
+  @Provides
+  @SingleIn(AppScope::class)
+  @GroupByAuthorStore
+  private fun groupByAuthor(factory: VoiceDataStoreFactory): DataStore<Boolean> {
+    return factory.boolean("groupByAuthor", defaultValue = false)
+  }
 }
 
 private class LegacyDarkThemeMigration(

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="cover.search.recent.content_description">Recent query</string>
     <!-- Generic title for artwork shown for a book or cover editor. -->
     <string name="cover.title">Cover</string>
+    <!-- Title for the group by author setting -->
+    <string name="settings_library_group_by_author_title">Group by Author</string>
     <!-- Pluralized duration text for sleep timer minutes. -->
     <plurals name="duration.minutes">
         <item quantity="one">%d minute</item>

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -22,6 +22,14 @@
     <string name="book.edit.name.label">Name</string>
     <!-- Title for the dialog that edits a book title. -->
     <string name="book.edit.title">Edit book</string>
+    <!-- Title for the dialog that edits a book's series. -->
+    <string name="book.edit.series.title">Edit series</string>
+    <!-- Label for a book series text field. -->
+    <string name="book.edit.series.label">Series</string>
+    <!-- Dropdown hint for a book series. -->
+    <string name="book.edit.series.dropdown_hint">Select an existing series or type a new one</string>
+    <!-- Action in the bottom sheet to edit series. -->
+    <string name="book.edit.series.action">Add to series</string>
     <!-- Snackbar message shown after creating a bookmark. -->
     <string name="bookmark.added.snackbar">Bookmark added</string>
     <!-- Relative timestamp for a bookmark created moments ago. -->

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/EditBookBottomSheetState.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/bottomSheet/EditBookBottomSheetState.kt
@@ -18,4 +18,5 @@ enum class BottomSheetItem(
   BookCategoryMarkAsNotStarted(StringsR.string.book_category_action_mark_not_started, VoiceIcons.HourglassEmpty),
   BookCategoryMarkAsCurrent(StringsR.string.book_category_action_mark_current, VoiceIcons.NotStarted),
   BookCategoryMarkAsCompleted(StringsR.string.book_category_action_mark_completed, VoiceIcons.Done),
+  BookSeries(StringsR.string.book_edit_series_action, VoiceIcons.CollectionsBookmark),
 }

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/di/BookOverviewGraph.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/di/BookOverviewGraph.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.GraphExtension
 import voice.features.bookOverview.bottomSheet.BottomSheetViewModel
 import voice.features.bookOverview.deleteBook.DeleteBookViewModel
 import voice.features.bookOverview.editTitle.EditBookTitleViewModel
+import voice.features.bookOverview.editSeries.EditBookSeriesViewModel
 import voice.features.bookOverview.fileCover.FileCoverViewModel
 import voice.features.bookOverview.overview.BookOverviewViewModel
 
@@ -18,6 +19,7 @@ interface BookOverviewGraph {
   val bottomSheetViewModel: BottomSheetViewModel
   val deleteBookViewModel: DeleteBookViewModel
   val fileCoverViewModel: FileCoverViewModel
+  val editBookSeriesViewModel: EditBookSeriesViewModel
 
   @GraphExtension.Factory
   @ContributesTo(AppScope::class)

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesDialog.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesDialog.kt
@@ -1,0 +1,119 @@
+package voice.features.bookOverview.editSeries
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import voice.core.strings.R as StringsR
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun EditBookSeriesDialog(
+  onDismiss: () -> Unit,
+  onConfirm: () -> Unit,
+  viewState: EditBookSeriesState,
+  onUpdateSeries: (String) -> Unit,
+  onUpdatePart: (String) -> Unit,
+) {
+  var expanded by remember { mutableStateOf(false) }
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = {
+      Text(text = stringResource(StringsR.string.book_edit_series_title))
+    },
+    confirmButton = {
+      Button(
+        onClick = onConfirm,
+      ) {
+        Text(stringResource(id = StringsR.string.common_dialog_confirm))
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(id = StringsR.string.common_dialog_cancel))
+      }
+    },
+    text = {
+      Column {
+        if (viewState.suggestedSeries.isNotEmpty()) {
+          ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+          ) {
+            TextField(
+              value = viewState.currentSeries,
+              onValueChange = {
+                  expanded = true
+                  onUpdateSeries(it)
+              },
+              label = {
+                Text(stringResource(StringsR.string.book_edit_series_label))
+              },
+              trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+              },
+              colors = ExposedDropdownMenuDefaults.textFieldColors(),
+              modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable, enabled = true).fillMaxWidth(),
+            )
+            ExposedDropdownMenu(
+              expanded = expanded,
+              onDismissRequest = { expanded = false },
+            ) {
+              val filteredOptions = viewState.suggestedSeries.filter {
+                  it.contains(viewState.currentSeries, ignoreCase = true)
+              }
+              filteredOptions.forEach { selectionOption ->
+                DropdownMenuItem(
+                  text = { Text(selectionOption) },
+                  onClick = {
+                    onUpdateSeries(selectionOption)
+                    expanded = false
+                  }
+                )
+              }
+            }
+          }
+        } else {
+          TextField(
+            value = viewState.currentSeries,
+            onValueChange = onUpdateSeries,
+            label = {
+              Text(stringResource(StringsR.string.book_edit_series_label))
+            },
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        TextField(
+          value = viewState.currentPart,
+          onValueChange = onUpdatePart,
+          label = {
+            Text("Part (Optional)")
+          },
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    },
+  )
+}

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesState.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesState.kt
@@ -1,0 +1,11 @@
+package voice.features.bookOverview.editSeries
+
+import voice.core.data.BookId
+
+internal data class EditBookSeriesState(
+  val bookId: BookId,
+  val author: String?,
+  val currentSeries: String,
+  val currentPart: String,
+  val suggestedSeries: List<String>,
+)

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/editSeries/EditBookSeriesViewModel.kt
@@ -1,0 +1,84 @@
+package voice.features.bookOverview.editSeries
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import voice.core.data.BookId
+import voice.core.data.repo.BookRepository
+import voice.features.bookOverview.bottomSheet.BottomSheetItem
+import voice.features.bookOverview.bottomSheet.BottomSheetItemViewModel
+import voice.features.bookOverview.di.BookOverviewScope
+
+@SingleIn(BookOverviewScope::class)
+@ContributesIntoSet(BookOverviewScope::class)
+class EditBookSeriesViewModel(private val repo: BookRepository) : BottomSheetItemViewModel {
+
+  private val scope = MainScope()
+
+  private val _state = mutableStateOf<EditBookSeriesState?>(null)
+  internal val state: State<EditBookSeriesState?> get() = _state
+
+  override suspend fun items(bookId: BookId): List<BottomSheetItem> {
+    return listOf(BottomSheetItem.BookSeries)
+  }
+
+  override suspend fun onItemClick(
+    bookId: BookId,
+    item: BottomSheetItem,
+  ) {
+    if (item != BottomSheetItem.BookSeries) return
+    val book = repo.get(bookId) ?: return
+    
+    // Find all series for this author
+    val author = book.content.author
+    val suggestedSeries = if (author != null) {
+        repo.all()
+            .filter { it.content.author == author && !it.content.series.isNullOrBlank() }
+            .mapNotNull { it.content.series }
+            .distinct()
+            .sorted()
+    } else {
+        emptyList()
+    }
+
+    _state.value = EditBookSeriesState(
+      bookId = bookId,
+      author = author,
+      currentSeries = book.content.series.orEmpty(),
+      currentPart = book.content.part.orEmpty(),
+      suggestedSeries = suggestedSeries,
+    )
+  }
+
+  internal fun onDismiss() {
+    _state.value = null
+  }
+
+  internal fun onUpdateSeries(series: String) {
+    _state.value = _state.value?.copy(currentSeries = series)
+  }
+
+  internal fun onUpdatePart(part: String) {
+    _state.value = _state.value?.copy(currentPart = part)
+  }
+
+  internal fun onConfirm() {
+    val state = _state.value
+    if (state != null) {
+      scope.launch {
+        repo.updateBook(state.bookId) {
+          val seriesToSave = state.currentSeries.trim().takeIf { it.isNotEmpty() }
+          val partToSave = state.currentPart.trim().takeIf { it.isNotEmpty() }
+          it.copy(
+            series = seriesToSave,
+            part = partToSave,
+          )
+        }
+      }
+    }
+    _state.value = null
+  }
+}

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewItemViewState.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewItemViewState.kt
@@ -14,6 +14,8 @@ data class BookOverviewItemViewState(
   val progress: Float,
   val id: BookId,
   val remainingTime: String,
+  val series: String?,
+  val seriesPart: String?,
 )
 
 internal fun Book.toItemViewState() = BookOverviewItemViewState(
@@ -23,6 +25,8 @@ internal fun Book.toItemViewState() = BookOverviewItemViewState(
   id = id,
   progress = progress(),
   remainingTime = formatTime(duration - position),
+  series = content.series,
+  seriesPart = content.part,
 )
 
 private fun Book.progress(): Float {

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
@@ -164,11 +164,22 @@ class BookOverviewViewModel(
                   BookOverviewItem.AuthorGroup(
                     author = author,
                     category = category,
-                    books = authorBooks.map { book ->
-                      androidx.compose.runtime.key(book.id.value) {
-                        book.itemViewState(currentBookId, { livePlaybackState.value })
-                      }
-                    },
+                    seriesGroups = authorBooks.groupBy { it.content.series }
+                      .map { (series, seriesBooks) ->
+                        BookOverviewItem.SeriesGroup(
+                          seriesName = series,
+                          books = seriesBooks.sortedWith { book1, book2 ->
+                            var cmp = nullsLast(String.CASE_INSENSITIVE_ORDER).compare(book1.content.part, book2.content.part)
+                            if (cmp != 0) return@sortedWith cmp
+                            String.CASE_INSENSITIVE_ORDER.compare(book1.content.name, book2.content.name)
+                          }.map { book ->
+                            androidx.compose.runtime.key(book.id.value) {
+                              book.itemViewState(currentBookId, { livePlaybackState.value })
+                            }
+                          }
+                        )
+                      }.sortedWith(compareBy(nullsLast(String.CASE_INSENSITIVE_ORDER)) { it.seriesName }),
+                    bookCount = authorBooks.size,
                     isExpanded = expandedAuthorsSet.contains("${category.name}_$author"),
                   ),
                 )
@@ -263,6 +274,8 @@ class BookOverviewViewModel(
                 progress = book.progress / 100F,
                 id = book.id,
                 remainingTime = book.remaining,
+                series = null,
+                seriesPart = null,
               ),
             ),
           )

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
@@ -77,6 +77,8 @@ class BookOverviewViewModel(
   private val experimentalPlaybackPersistenceFeatureFlag: FeatureFlag<Boolean>,
   @KioskModeFeatureFlagQualifier
   private val kioskModeFeatureFlag: FeatureFlag<Boolean>,
+  @voice.core.data.store.GroupByAuthorStore
+  private val groupByAuthorStore: DataStore<Boolean>,
   dispatcherProvider: DispatcherProvider,
 ) {
 
@@ -84,6 +86,7 @@ class BookOverviewViewModel(
   private var searchActive by mutableStateOf(false)
   private var query by mutableStateOf("")
   private var dialog by mutableStateOf<BookOverviewViewState.Dialog?>(null)
+  private val expandedAuthors = mutableStateOf<Set<String>>(emptySet())
 
   fun attach() {
     mediaScanner.scan()
@@ -132,21 +135,53 @@ class BookOverviewViewModel(
       remember { mutableStateOf(null) }
     }
 
+    val groupByAuthor = remember { groupByAuthorStore.data }
+      .collectAsState(initial = false).value
+    val expandedAuthorsSet = expandedAuthors.value
+
     return BookOverviewViewState(
       layoutMode = layoutMode,
       books = books
         .groupBy {
           it.category
         }
-        .mapValues { (category, books) ->
-          books
-            .sortedWith(category.comparator)
-            .associate { book ->
-              book.id to book.itemViewState(
-                currentBookId = currentBookId,
-                livePlaybackState = { livePlaybackState.value },
-              )
+        .mapValues { (category, booksInCategory) ->
+          val sortedBooks = booksInCategory.sortedWith(category.comparator)
+          if (groupByAuthor) {
+            val items = mutableListOf<BookOverviewItem>()
+            val groupedByAuthor = sortedBooks.groupBy { it.content.author }
+            groupedByAuthor.forEach { (author, authorBooks) ->
+              if (author == null) {
+                items.addAll(
+                  authorBooks.map { book ->
+                    androidx.compose.runtime.key(book.id.value) {
+                      BookOverviewItem.SingleBook(book.itemViewState(currentBookId, { livePlaybackState.value }))
+                    }
+                  },
+                )
+              } else {
+                items.add(
+                  BookOverviewItem.AuthorGroup(
+                    author = author,
+                    category = category,
+                    books = authorBooks.map { book ->
+                      androidx.compose.runtime.key(book.id.value) {
+                        book.itemViewState(currentBookId, { livePlaybackState.value })
+                      }
+                    },
+                    isExpanded = expandedAuthorsSet.contains("${category.name}_$author"),
+                  ),
+                )
+              }
             }
+            items.toList()
+          } else {
+            sortedBooks.map { book ->
+              androidx.compose.runtime.key(book.id.value) {
+                BookOverviewItem.SingleBook(book.itemViewState(currentBookId, { livePlaybackState.value }))
+              }
+            }
+          }
         }
         .toSortedMap(),
       playButtonState = if (playState == PlayStateManager.PlayState.Playing) {
@@ -218,15 +253,17 @@ class BookOverviewViewModel(
     return BookOverviewViewState(
       layoutMode = BookOverviewLayoutMode.List,
       books = mapOf(
-        BookOverviewCategory.CURRENT to KioskModeDemoData.demoAudiobooks.associate { book ->
-          book.id to mutableStateOf(
-            BookOverviewItemViewState(
-              name = book.title,
-              author = book.author,
-              cover = book.coverUrl,
-              progress = book.progress / 100F,
-              id = book.id,
-              remainingTime = book.remaining,
+        BookOverviewCategory.CURRENT to KioskModeDemoData.demoAudiobooks.map { book ->
+          BookOverviewItem.SingleBook(
+            mutableStateOf(
+              BookOverviewItemViewState(
+                name = book.title,
+                author = book.author,
+                cover = book.coverUrl,
+                progress = book.progress / 100F,
+                id = book.id,
+                remainingTime = book.remaining,
+              ),
             ),
           )
         },
@@ -263,6 +300,16 @@ class BookOverviewViewModel(
     dialog = null
     scope.launch {
       folderPickerMovedDialogShownStore.updateData { true }
+    }
+  }
+
+  fun toggleAuthorExpanded(category: BookOverviewCategory, author: String) {
+    val key = "${category.name}_$author"
+    val current = expandedAuthors.value
+    expandedAuthors.value = if (current.contains(key)) {
+      current - key
+    } else {
+      current + key
     }
   }
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
@@ -79,6 +79,8 @@ class BookOverviewViewModel(
   private val kioskModeFeatureFlag: FeatureFlag<Boolean>,
   @voice.core.data.store.GroupByAuthorStore
   private val groupByAuthorStore: DataStore<Boolean>,
+  @voice.core.data.store.ExpandedAuthorsStore
+  private val expandedAuthorsStore: DataStore<Set<String>>,
   dispatcherProvider: DispatcherProvider,
 ) {
 
@@ -86,7 +88,6 @@ class BookOverviewViewModel(
   private var searchActive by mutableStateOf(false)
   private var query by mutableStateOf("")
   private var dialog by mutableStateOf<BookOverviewViewState.Dialog?>(null)
-  private val expandedAuthors = mutableStateOf<Set<String>>(emptySet())
 
   fun attach() {
     mediaScanner.scan()
@@ -137,7 +138,8 @@ class BookOverviewViewModel(
 
     val groupByAuthor = remember { groupByAuthorStore.data }
       .collectAsState(initial = false).value
-    val expandedAuthorsSet = expandedAuthors.value
+    val expandedAuthorsSet = remember { expandedAuthorsStore.data }
+      .collectAsState(initial = emptySet()).value
 
     return BookOverviewViewState(
       layoutMode = layoutMode,
@@ -318,11 +320,14 @@ class BookOverviewViewModel(
 
   fun toggleAuthorExpanded(category: BookOverviewCategory, author: String) {
     val key = "${category.name}_$author"
-    val current = expandedAuthors.value
-    expandedAuthors.value = if (current.contains(key)) {
-      current - key
-    } else {
-      current + key
+    scope.launch {
+      expandedAuthorsStore.updateData { current ->
+        if (current.contains(key)) {
+          current - key
+        } else {
+          current + key
+        }
+      }
     }
   }
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewState.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewState.kt
@@ -14,10 +14,16 @@ sealed interface BookOverviewItem {
       get() = state.value.id.value
   }
 
+  data class SeriesGroup(
+    val seriesName: String?,
+    val books: List<State<BookOverviewItemViewState>>
+  )
+
   data class AuthorGroup(
     val author: String,
     val category: BookOverviewCategory,
-    val books: List<State<BookOverviewItemViewState>>,
+    val seriesGroups: List<SeriesGroup>,
+    val bookCount: Int,
     val isExpanded: Boolean,
   ) : BookOverviewItem {
     override val id: String

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewState.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewState.kt
@@ -6,8 +6,28 @@ import voice.core.data.BookId
 import voice.features.bookOverview.search.BookSearchViewState
 
 @Immutable
+sealed interface BookOverviewItem {
+  val id: String
+
+  data class SingleBook(val state: State<BookOverviewItemViewState>) : BookOverviewItem {
+    override val id: String
+      get() = state.value.id.value
+  }
+
+  data class AuthorGroup(
+    val author: String,
+    val category: BookOverviewCategory,
+    val books: List<State<BookOverviewItemViewState>>,
+    val isExpanded: Boolean,
+  ) : BookOverviewItem {
+    override val id: String
+      get() = "author_${category.name}_$author"
+  }
+}
+
+@Immutable
 data class BookOverviewViewState(
-  val books: Map<BookOverviewCategory, Map<BookId, State<BookOverviewItemViewState>>>,
+  val books: Map<BookOverviewCategory, List<BookOverviewItem>>,
   val layoutMode: BookOverviewLayoutMode,
   val playButtonState: PlayButtonState?,
   val showAddBookHint: Boolean,

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
@@ -49,6 +49,7 @@ import voice.features.bookOverview.bottomSheet.BottomSheetContent
 import voice.features.bookOverview.bottomSheet.BottomSheetItem
 import voice.features.bookOverview.deleteBook.DeleteBookDialog
 import voice.features.bookOverview.di.BookOverviewGraph
+import voice.features.bookOverview.editSeries.EditBookSeriesDialog
 import voice.features.bookOverview.editTitle.EditBookTitleDialog
 import voice.features.bookOverview.overview.BookOverviewCategory
 import voice.features.bookOverview.overview.BookOverviewItem
@@ -82,6 +83,7 @@ fun BookOverviewScreen(modifier: Modifier = Modifier) {
   }
   val bookOverviewViewModel = bookGraph.bookOverviewViewModel
   val editBookTitleViewModel = bookGraph.editBookTitleViewModel
+  val editBookSeriesViewModel = bookGraph.editBookSeriesViewModel
   val bottomSheetViewModel = bookGraph.bottomSheetViewModel
   val deleteBookViewModel = bookGraph.deleteBookViewModel
   val fileCoverViewModel = bookGraph.fileCoverViewModel
@@ -136,6 +138,16 @@ fun BookOverviewScreen(modifier: Modifier = Modifier) {
       onConfirmEditTitle = editBookTitleViewModel::onConfirmEditTitle,
       viewState = editBookTitleState,
       onUpdateEditTitle = editBookTitleViewModel::onUpdateEditTitle,
+    )
+  }
+  val editBookSeriesState = editBookSeriesViewModel.state.value
+  if (editBookSeriesState != null) {
+    EditBookSeriesDialog(
+      onDismiss = editBookSeriesViewModel::onDismiss,
+      onConfirm = editBookSeriesViewModel::onConfirm,
+      viewState = editBookSeriesState,
+      onUpdateSeries = editBookSeriesViewModel::onUpdateSeries,
+      onUpdatePart = editBookSeriesViewModel::onUpdatePart,
     )
   }
 
@@ -315,6 +327,8 @@ internal class BookOverviewPreviewParameterProvider : PreviewParameterProvider<B
       progress = 0.8F,
       id = BookId(Uuid.random().toString()),
       remainingTime = "01:04",
+      series = "Test Series",
+      seriesPart = "1",
     )
   }
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
@@ -51,6 +51,7 @@ import voice.features.bookOverview.deleteBook.DeleteBookDialog
 import voice.features.bookOverview.di.BookOverviewGraph
 import voice.features.bookOverview.editTitle.EditBookTitleDialog
 import voice.features.bookOverview.overview.BookOverviewCategory
+import voice.features.bookOverview.overview.BookOverviewItem
 import voice.features.bookOverview.overview.BookOverviewItemViewState
 import voice.features.bookOverview.overview.BookOverviewLayoutMode
 import voice.features.bookOverview.overview.BookOverviewViewState
@@ -117,6 +118,7 @@ fun BookOverviewScreen(modifier: Modifier = Modifier) {
     onSearchQueryChange = bookOverviewViewModel::onSearchQueryChange,
     onSearchBookClick = bookOverviewViewModel::onSearchBookClick,
     onPermissionBugCardClick = bookOverviewViewModel::onPermissionBugCardClick,
+    onToggleAuthorExpanded = bookOverviewViewModel::toggleAuthorExpanded,
   )
   val deleteBookViewState = deleteBookViewModel.state.value
   if (deleteBookViewState != null) {
@@ -180,6 +182,7 @@ internal fun BookOverview(
   onSearchQueryChange: (String) -> Unit,
   onSearchBookClick: (BookId) -> Unit,
   onPermissionBugCardClick: () -> Unit,
+  onToggleAuthorExpanded: (BookOverviewCategory, String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -222,6 +225,7 @@ internal fun BookOverview(
             onBookLongClick = onBookLongClick,
             showPermissionBugCard = viewState.showStoragePermissionBugCard,
             onPermissionBugCardClick = onPermissionBugCardClick,
+            onToggleAuthorExpanded = onToggleAuthorExpanded,
           )
         }
         BookOverviewLayoutMode.Grid -> {
@@ -231,6 +235,7 @@ internal fun BookOverview(
             onBookLongClick = onBookLongClick,
             showPermissionBugCard = viewState.showStoragePermissionBugCard,
             onPermissionBugCardClick = onPermissionBugCardClick,
+            onToggleAuthorExpanded = onToggleAuthorExpanded,
           )
         }
       }
@@ -295,6 +300,7 @@ fun BookOverviewPreview(
       onSearchQueryChange = {},
       onSearchBookClick = {},
       onPermissionBugCardClick = {},
+      onToggleAuthorExpanded = { _, _ -> },
     )
   }
 }
@@ -315,19 +321,17 @@ internal class BookOverviewPreviewParameterProvider : PreviewParameterProvider<B
   override val values = sequenceOf(
     BookOverviewViewState(
       books = mapOf(
-        BookOverviewCategory.CURRENT to buildMap {
+        BookOverviewCategory.CURRENT to buildList {
           repeat(10) {
-            put(
-              BookId(Uuid.random().toString()),
-              mutableStateOf(book()),
+            add(
+              BookOverviewItem.SingleBook(mutableStateOf(book())),
             )
           }
         },
-        BookOverviewCategory.FINISHED to buildMap {
+        BookOverviewCategory.FINISHED to buildList {
           repeat(2) {
-            put(
-              BookId(Uuid.random().toString()),
-              mutableStateOf(book()),
+            add(
+              BookOverviewItem.SingleBook(mutableStateOf(book())),
             )
           }
         },

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/GridBooks.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/GridBooks.kt
@@ -40,13 +40,20 @@ import voice.features.bookOverview.overview.BookOverviewItemViewState
 import kotlin.math.roundToInt
 import voice.core.ui.R as UiR
 
+import voice.features.bookOverview.overview.BookOverviewItem
+import voice.core.ui.icons.VoiceIcons
+import androidx.compose.material3.Icon
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+
 @Composable
 internal fun GridBooks(
-  books: Map<BookOverviewCategory, Map<BookId, State<BookOverviewItemViewState>>>,
+  books: Map<BookOverviewCategory, List<BookOverviewItem>>,
   onBookClick: (BookId) -> Unit,
   onBookLongClick: (BookId) -> Unit,
   showPermissionBugCard: Boolean,
   onPermissionBugCardClick: () -> Unit,
+  onToggleAuthorExpanded: (BookOverviewCategory, String) -> Unit,
 ) {
   val cellCount = gridColumnCount()
   LazyVerticalGrid(
@@ -62,8 +69,8 @@ internal fun GridBooks(
         PermissionBugCard(onPermissionBugCardClick)
       }
     }
-    books.forEach { (category, books) ->
-      if (books.isEmpty()) return@forEach
+    books.forEach { (category, booksInCategory) ->
+      if (booksInCategory.isEmpty()) return@forEach
       item(
         span = { GridItemSpan(maxLineSpan) },
         key = category,
@@ -74,16 +81,48 @@ internal fun GridBooks(
           category = category,
         )
       }
-      items(
-        items = books.toList(),
-        key = { (bookId, _) -> bookId.value },
-        contentType = { "item" },
-      ) { (_, bookState) ->
-        GridBook(
-          book = bookState.value,
-          onBookClick = onBookClick,
-          onBookLongClick = onBookLongClick,
-        )
+      booksInCategory.forEach { item ->
+        when (item) {
+          is BookOverviewItem.SingleBook -> {
+            item(
+              key = item.id,
+              contentType = "item",
+            ) {
+              GridBook(
+                book = item.state.value,
+                onBookClick = onBookClick,
+                onBookLongClick = onBookLongClick,
+              )
+            }
+          }
+          is BookOverviewItem.AuthorGroup -> {
+            item(
+              span = { GridItemSpan(maxLineSpan) },
+              key = item.id,
+              contentType = "author_group",
+            ) {
+              AuthorGroupGridHeader(
+                author = item.author,
+                isExpanded = item.isExpanded,
+                bookCount = item.books.size,
+                onToggleExpanded = { onToggleAuthorExpanded(item.category, item.author) },
+              )
+            }
+            if (item.isExpanded) {
+              items(
+                items = item.books,
+                key = { bookState -> bookState.value.id.value },
+                contentType = { "item" },
+              ) { bookState ->
+                GridBook(
+                  book = bookState.value,
+                  onBookClick = onBookClick,
+                  onBookLongClick = onBookLongClick,
+                )
+              }
+            }
+          }
+        }
       }
       item(
         span = { GridItemSpan(maxLineSpan) },
@@ -91,6 +130,50 @@ internal fun GridBooks(
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
       }
     }
+  }
+}
+
+@Composable
+internal fun AuthorGroupGridHeader(
+  author: String,
+  isExpanded: Boolean,
+  bookCount: Int,
+  onToggleExpanded: () -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(MaterialTheme.shapes.medium)
+      .clickable { onToggleExpanded() }
+      .padding(horizontal = 8.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = VoiceIcons.Person,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Column(
+      modifier = Modifier
+        .weight(1f)
+        .padding(horizontal = 16.dp),
+    ) {
+      Text(
+        text = author,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      Text(
+        text = "$bookCount books",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    Icon(
+      imageVector = if (isExpanded) VoiceIcons.ExpandMore else VoiceIcons.ChevronRight,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
   }
 }
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/GridBooks.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/GridBooks.kt
@@ -104,21 +104,32 @@ internal fun GridBooks(
               AuthorGroupGridHeader(
                 author = item.author,
                 isExpanded = item.isExpanded,
-                bookCount = item.books.size,
+                bookCount = item.bookCount,
                 onToggleExpanded = { onToggleAuthorExpanded(item.category, item.author) },
               )
             }
             if (item.isExpanded) {
-              items(
-                items = item.books,
-                key = { bookState -> bookState.value.id.value },
-                contentType = { "item" },
-              ) { bookState ->
-                GridBook(
-                  book = bookState.value,
-                  onBookClick = onBookClick,
-                  onBookLongClick = onBookLongClick,
-                )
+              item.seriesGroups.forEach { seriesGroup ->
+                if (seriesGroup.seriesName != null) {
+                  item(
+                    span = { GridItemSpan(maxLineSpan) },
+                    key = "${item.id}_series_${seriesGroup.seriesName}",
+                    contentType = "series_group",
+                  ) {
+                    SeriesGridHeader(seriesName = seriesGroup.seriesName)
+                  }
+                }
+                items(
+                  items = seriesGroup.books,
+                  key = { bookState -> bookState.value.id.value },
+                  contentType = { "item" },
+                ) { bookState ->
+                  GridBook(
+                    book = bookState.value,
+                    onBookClick = onBookClick,
+                    onBookLongClick = onBookLongClick,
+                  )
+                }
               }
             }
           }
@@ -220,6 +231,17 @@ internal fun GridBook(
         overflow = TextOverflow.Ellipsis,
       )
 
+      if (book.series != null) {
+        val partString = if (!book.seriesPart.isNullOrBlank()) ", Part ${book.seriesPart}" else ""
+        Text(
+          text = "${book.series}$partString",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+      }
+
       BookRemainingProgressRow(
         remainingTime = book.remainingTime,
         progress = book.progress,
@@ -253,3 +275,14 @@ private fun GridBookPreviewWithProgress() {
 private fun GridBookPreviewWithoutProgress() {
   GridBook(BookOverviewPreviewParameterProvider().book().copy(progress = 0f), {}, {})
 }
+
+@Composable
+internal fun SeriesGridHeader(seriesName: String) {
+  Text(
+    text = seriesName,
+    style = MaterialTheme.typography.titleSmall,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
+  )
+}
+

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/ListBooks.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/ListBooks.kt
@@ -36,13 +36,19 @@ import voice.features.bookOverview.overview.BookOverviewCategory
 import voice.features.bookOverview.overview.BookOverviewItemViewState
 import voice.core.ui.R as UiR
 
+import voice.features.bookOverview.overview.BookOverviewItem
+import voice.core.ui.icons.VoiceIcons
+import androidx.compose.material3.Icon
+import androidx.compose.foundation.clickable
+
 @Composable
 internal fun ListBooks(
-  books: Map<BookOverviewCategory, Map<BookId, State<BookOverviewItemViewState>>>,
+  books: Map<BookOverviewCategory, List<BookOverviewItem>>,
   onBookClick: (BookId) -> Unit,
   onBookLongClick: (BookId) -> Unit,
   showPermissionBugCard: Boolean,
   onPermissionBugCardClick: () -> Unit,
+  onToggleAuthorExpanded: (BookOverviewCategory, String) -> Unit,
 ) {
   LazyColumn(
     verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -53,8 +59,8 @@ internal fun ListBooks(
         PermissionBugCard(onPermissionBugCardClick)
       }
     }
-    books.forEach { (category, books) ->
-      if (books.isEmpty()) return@forEach
+    books.forEach { (category, booksInCategory) ->
+      if (booksInCategory.isEmpty()) return@forEach
       stickyHeader(
         key = category,
         contentType = "header",
@@ -67,21 +73,97 @@ internal fun ListBooks(
           category = category,
         )
       }
-      items(
-        items = books.toList(),
-        key = { (bookId, _) -> bookId.value },
-        contentType = { "item" },
-      ) { (_, bookState) ->
-        ListBookRow(
-          book = bookState.value,
-          onBookClick = onBookClick,
-          onBookLongClick = onBookLongClick,
-        )
+      booksInCategory.forEach { item ->
+        when (item) {
+          is BookOverviewItem.SingleBook -> {
+            item(
+              key = item.id,
+              contentType = "item",
+            ) {
+              ListBookRow(
+                book = item.state.value,
+                onBookClick = onBookClick,
+                onBookLongClick = onBookLongClick,
+              )
+            }
+          }
+          is BookOverviewItem.AuthorGroup -> {
+            item(
+              key = item.id,
+              contentType = "author_group",
+            ) {
+              AuthorGroupRow(
+                author = item.author,
+                isExpanded = item.isExpanded,
+                bookCount = item.books.size,
+                onToggleExpanded = { onToggleAuthorExpanded(item.category, item.author) },
+              )
+            }
+            if (item.isExpanded) {
+              items(
+                items = item.books,
+                key = { bookState -> bookState.value.id.value },
+                contentType = { "item" },
+              ) { bookState ->
+                ListBookRow(
+                  modifier = Modifier.padding(start = 16.dp),
+                  book = bookState.value,
+                  onBookClick = onBookClick,
+                  onBookLongClick = onBookLongClick,
+                )
+              }
+            }
+          }
+        }
       }
       item {
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
       }
     }
+  }
+}
+
+@Composable
+internal fun AuthorGroupRow(
+  author: String,
+  isExpanded: Boolean,
+  bookCount: Int,
+  onToggleExpanded: () -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(MaterialTheme.shapes.medium)
+      .clickable { onToggleExpanded() }
+      .padding(horizontal = 16.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = VoiceIcons.Person,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Column(
+      modifier = Modifier
+        .weight(1f)
+        .padding(horizontal = 16.dp),
+    ) {
+      Text(
+        text = author,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      Text(
+        text = "$bookCount books",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    Icon(
+      imageVector = if (isExpanded) VoiceIcons.ExpandMore else VoiceIcons.ChevronRight,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
   }
 }
 

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/ListBooks.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/ListBooks.kt
@@ -95,22 +95,32 @@ internal fun ListBooks(
               AuthorGroupRow(
                 author = item.author,
                 isExpanded = item.isExpanded,
-                bookCount = item.books.size,
+                bookCount = item.bookCount,
                 onToggleExpanded = { onToggleAuthorExpanded(item.category, item.author) },
               )
             }
             if (item.isExpanded) {
-              items(
-                items = item.books,
-                key = { bookState -> bookState.value.id.value },
-                contentType = { "item" },
-              ) { bookState ->
-                ListBookRow(
-                  modifier = Modifier.padding(start = 16.dp),
-                  book = bookState.value,
-                  onBookClick = onBookClick,
-                  onBookLongClick = onBookLongClick,
-                )
+              item.seriesGroups.forEach { seriesGroup ->
+                if (seriesGroup.seriesName != null) {
+                  item(
+                    key = "${item.id}_series_${seriesGroup.seriesName}",
+                    contentType = "series_group",
+                  ) {
+                    SeriesListHeader(seriesName = seriesGroup.seriesName)
+                  }
+                }
+                items(
+                  items = seriesGroup.books,
+                  key = { bookState -> bookState.value.id.value },
+                  contentType = { "item" },
+                ) { bookState ->
+                  ListBookRow(
+                    modifier = Modifier.padding(start = 16.dp),
+                    book = bookState.value,
+                    onBookClick = onBookClick,
+                    onBookLongClick = onBookLongClick,
+                  )
+                }
               }
             }
           }
@@ -205,6 +215,16 @@ internal fun ListBookRow(
             maxLines = 2,
           )
 
+          if (book.series != null) {
+            val partString = if (!book.seriesPart.isNullOrBlank()) ", Part ${book.seriesPart}" else ""
+            Text(
+              text = "${book.series}$partString",
+              style = MaterialTheme.typography.labelMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              maxLines = 1,
+            )
+          }
+
           BookRemainingProgressRow(
             modifier = Modifier
               .padding(end = 12.dp),
@@ -264,3 +284,14 @@ private fun ListBookRowPreviewWithProgress() {
 private fun ListBookRowPreviewWithoutProgress() {
   ListBookRow(BookOverviewPreviewParameterProvider().book().copy(progress = 0f), {}, {})
 }
+
+@Composable
+internal fun SeriesListHeader(seriesName: String) {
+  Text(
+    text = seriesName,
+    style = MaterialTheme.typography.titleSmall,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 4.dp),
+  )
+}
+

--- a/features/bookOverview/src/test/kotlin/voice/features/bookOverview/overview/BookOverviewViewModelTest.kt
+++ b/features/bookOverview/src/test/kotlin/voice/features/bookOverview/overview/BookOverviewViewModelTest.kt
@@ -83,6 +83,8 @@ class BookOverviewViewModelTest {
       folderPickerInSettingsFeatureFlag = MemoryFeatureFlag(false),
       experimentalPlaybackPersistenceFeatureFlag = MemoryFeatureFlag(true),
       kioskModeFeatureFlag = MemoryFeatureFlag(false),
+      groupByAuthorStore = MemoryDataStore(false),
+      expandedAuthorsStore = MemoryDataStore(emptySet()),
       dispatcherProvider = dispatcherProvider,
     )
 
@@ -93,7 +95,7 @@ class BookOverviewViewModelTest {
       val initial = awaitItem()
       val initialCurrentItem = initial.currentBook(currentBook.id)
       val initialOtherItem = initial.currentBook(otherBook.id)
-      val initialKeys = initial.books.getValue(BookOverviewCategory.CURRENT).keys.toList()
+      val initialKeys = initial.books.getValue(BookOverviewCategory.CURRENT).map { it.id }
 
       assertEquals(expected = currentBook.toItemViewState(), actual = initialCurrentItem)
       assertEquals(expected = otherBook.toItemViewState(), actual = initialOtherItem)
@@ -108,7 +110,7 @@ class BookOverviewViewModelTest {
       livePlaybackFlow.value = livePlaybackState
       yield()
 
-      assertEquals(expected = initialKeys, actual = initial.books.getValue(BookOverviewCategory.CURRENT).keys.toList())
+      assertEquals(expected = initialKeys, actual = initial.books.getValue(BookOverviewCategory.CURRENT).map { it.id })
       assertEquals(expected = currentBook.overlay(livePlaybackState).toItemViewState(), actual = initial.currentBook(currentBook.id))
       assertEquals(expected = initialOtherItem, actual = initial.currentBook(otherBook.id))
       expectNoEvents()
@@ -148,6 +150,8 @@ class BookOverviewViewModelTest {
       folderPickerInSettingsFeatureFlag = MemoryFeatureFlag(false),
       experimentalPlaybackPersistenceFeatureFlag = MemoryFeatureFlag(false),
       kioskModeFeatureFlag = MemoryFeatureFlag(true),
+      groupByAuthorStore = MemoryDataStore(false),
+      expandedAuthorsStore = MemoryDataStore(emptySet()),
       dispatcherProvider = dispatcherProvider,
     )
 
@@ -157,9 +161,9 @@ class BookOverviewViewModelTest {
       val state = awaitItem()
       assertEquals(
         expected = KioskModeDemoData.demoAudiobooks.map {
-          it.id
+          it.id.value
         },
-        actual = state.books.getValue(BookOverviewCategory.CURRENT).keys.toList(),
+        actual = state.books.getValue(BookOverviewCategory.CURRENT).map { it.id },
       )
       assertEquals(expected = "Echoes of Tomorrow", actual = state.currentBook(KioskModeDemoData.currentlyPlaying.id).name)
     }
@@ -280,7 +284,7 @@ class BookOverviewViewModelTest {
   }
 
   private fun BookOverviewViewState.currentBook(bookId: BookId): BookOverviewItemViewState {
-    return books.getValue(BookOverviewCategory.CURRENT).getValue(bookId).value
+    return (books.getValue(BookOverviewCategory.CURRENT).first { it.id == bookId.value } as BookOverviewItem.SingleBook).state.value
   }
 
   private fun viewModel(
@@ -320,6 +324,8 @@ class BookOverviewViewModelTest {
       folderPickerInSettingsFeatureFlag = folderPickerInSettingsFeatureFlag,
       experimentalPlaybackPersistenceFeatureFlag = MemoryFeatureFlag(false),
       kioskModeFeatureFlag = MemoryFeatureFlag(false),
+      groupByAuthorStore = MemoryDataStore(false),
+      expandedAuthorsStore = MemoryDataStore(emptySet()),
       dispatcherProvider = dispatcherProvider,
     )
   }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
@@ -30,6 +30,7 @@ interface SettingsListener {
   fun onAppVersionClick()
 
   fun openDeveloperMenu()
+  fun toggleGroupByAuthor()
 
   companion object {
     fun noop() = object : SettingsListener {
@@ -57,6 +58,7 @@ interface SettingsListener {
       override fun openFolderPicker() {}
       override fun onAppVersionClick() {}
       override fun openDeveloperMenu() {}
+      override fun toggleGroupByAuthor() {}
     }
   }
 }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
@@ -60,6 +60,8 @@ class SettingsViewModel(
   @DeveloperMenuUnlockedStore
   private val developerMenuUnlockedStore: DataStore<Boolean>,
   private val dynamicColorAvailability: DynamicColorAvailability,
+  @voice.core.data.store.GroupByAuthorStore
+  private val groupByAuthorStore: DataStore<Boolean>,
   dispatcherProvider: DispatcherProvider,
 ) : SettingsListener {
 
@@ -87,6 +89,7 @@ class SettingsViewModel(
     val showThemeColorSchemePref = remember {
       dynamicColorAvailability.isSupported()
     }
+    val groupByAuthor by remember { groupByAuthorStore.data }.collectAsState(initial = false)
     return SettingsViewState(
       themeMode = themeMode,
       themeColorScheme = themeColorScheme,
@@ -110,6 +113,7 @@ class SettingsViewModel(
       showDeveloperMenu = showDeveloperMenu,
       showSupportDevelopment = appInfoProvider.supportDevelopmentIncluded,
       kioskMode = kioskMode,
+      groupByAuthor = groupByAuthor,
     )
   }
 
@@ -259,5 +263,11 @@ class SettingsViewModel(
 
   override fun openDeveloperMenu() {
     navigator.goTo(Destination.DeveloperSettings)
+  }
+
+  override fun toggleGroupByAuthor() {
+    mainScope.launch {
+      groupByAuthorStore.updateData { !it }
+    }
   }
 }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsViewState.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsViewState.kt
@@ -19,6 +19,7 @@ data class SettingsViewState(
   val showDeveloperMenu: Boolean,
   val showSupportDevelopment: Boolean,
   val kioskMode: Boolean,
+  val groupByAuthor: Boolean,
 ) {
 
   enum class Dialog {
@@ -45,6 +46,7 @@ data class SettingsViewState(
         showDeveloperMenu = true,
         showSupportDevelopment = true,
         kioskMode = false,
+        groupByAuthor = false,
       )
     }
   }

--- a/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
@@ -148,6 +148,27 @@ private fun Settings(
       }
 
       item {
+        ListItem(
+          modifier = Modifier.clickable { listener.toggleGroupByAuthor() },
+          leadingContent = {
+            Icon(
+              imageVector = VoiceIcons.Person,
+              contentDescription = stringResource(StringsR.string.settings_library_group_by_author_title),
+            )
+          },
+          headlineContent = { Text(stringResource(StringsR.string.settings_library_group_by_author_title)) },
+          trailingContent = {
+            Switch(
+              checked = viewState.groupByAuthor,
+              onCheckedChange = {
+                listener.toggleGroupByAuthor()
+              },
+            )
+          },
+        )
+      }
+
+      item {
         SeekTimeRow(viewState.seekTimeInSeconds) {
           listener.onSeekAmountRowClick()
         }

--- a/features/settings/src/test/kotlin/voice/features/settings/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/voice/features/settings/SettingsViewModelTest.kt
@@ -57,6 +57,7 @@ class SettingsViewModelTest {
   private val dynamicColorAvailability = mockk<DynamicColorAvailability> {
     every { isSupported() } returns true
   }
+  private val groupByAuthorStore = MemoryDataStore(false)
 
   private val viewModel = SettingsViewModel(
     themeModeStore = themeModeStore,
@@ -72,6 +73,7 @@ class SettingsViewModelTest {
     kioskModeFeatureFlag = kioskModeFeatureFlag,
     developerMenuUnlockedStore = developerMenuUnlockedStore,
     dynamicColorAvailability = dynamicColorAvailability,
+    groupByAuthorStore = groupByAuthorStore,
     dispatcherProvider = DispatcherProvider(scope.coroutineContext, scope.coroutineContext, scope.coroutineContext),
   )
 


### PR DESCRIPTION
# Pull Request: Add Group by Author Feature

## Description
This PR introduces a new "Group by Author" feature, allowing users to organize their books by author within each status category (Current, Finished, Not Started) on the main overview screen.

When enabled, the books will cluster into accordion-style author headers. Tapping an author header will expand or collapse the books by that author for that specific category. The expansion state is preserved during the session.

### Key Changes
*   **Settings Integration:** Added a "Group by Author" toggle switch to the Settings screen, persisted via `GroupByAuthorStore` DataStore.
*   **ViewModel Logic:** Updated `BookOverviewViewModel` to observe the grouping preference. The books are now transformed into `BookOverviewItem` which can be either a `SingleBook` or an `AuthorGroup`. It also manages the expansion state uniquely per category using a `Set<String>`.
*   **List View Support:** Implemented `AuthorGroupRow` in `ListBooks.kt` as an accordion header to expand/collapse author groups.
*   **Grid View Support:** Implemented `AuthorGroupGridHeader` in `GridBooks.kt` that intelligently spans the full width of the grid, ensuring an organized layout.
*   **Stable Recomposition:** Wrapped the nested items in Compose `key()` blocks to ensure flawless transitions and prevent UI crashes when toggling the setting.

