### PR TITLE
Add total progress indicator to playback screen

### DIFF
--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -280,4 +280,6 @@
     <string name="sleep_timer.dialog.title">Sweet dreams! 🌙</string>
     <!-- Sleep timer option and playback status for stopping at the end of a chapter. -->
     <string name="sleep_timer.end_of_chapter">End of Chapter</string>
+    <!-- Summary text for total book progress on the playback screen. -->
+    <string name="playback_total_progress_summary">%1$d%% Complete • %2$s remaining</string>
 </resources>

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/BookPlayViewModel.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/BookPlayViewModel.kt
@@ -135,6 +135,8 @@ class BookPlayViewModel(
       chapterName = currentMark.name.takeIf { hasMoreThanOneChapter },
       duration = currentMark.durationMs.milliseconds,
       playedTime = positionInCurrentMark.milliseconds,
+      totalDuration = book.duration.milliseconds,
+      totalPlayedTime = book.position.milliseconds,
       cover = book.content.coverUrl,
       skipSilence = book.content.skipSilence,
     )
@@ -151,6 +153,8 @@ class BookPlayViewModel(
       chapterName = currentlyPlaying.chapter,
       duration = 14.hours + 27.minutes,
       playedTime = 10.hours + 24.minutes,
+      totalDuration = 20.hours,
+      totalPlayedTime = 10.hours + 24.minutes,
       cover = book.coverUrl,
       skipSilence = false,
     )

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/BookPlayViewState.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/BookPlayViewState.kt
@@ -13,6 +13,8 @@ data class BookPlayViewState(
   val sleepTimerState: SleepTimerViewState,
   val playedTime: Duration,
   val duration: Duration,
+  val totalPlayedTime: Duration,
+  val totalDuration: Duration,
   val playing: Boolean,
   val cover: String?,
   val skipSilence: Boolean,

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayContent.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayContent.kt
@@ -57,7 +57,12 @@ internal fun BookPlayContent(
             onCurrentChapterClick = onCurrentChapterClick,
           )
         }
-        Spacer(modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.size(8.dp))
+        TotalProgressRow(
+          totalDuration = viewState.totalDuration,
+          totalPlayedTime = viewState.totalPlayedTime,
+        )
+        Spacer(modifier = Modifier.size(16.dp))
         SliderRow(
           duration = viewState.duration,
           playedTime = viewState.playedTime,
@@ -94,7 +99,12 @@ internal fun BookPlayContent(
           onCurrentChapterClick = onCurrentChapterClick,
         )
       }
-      Spacer(modifier = Modifier.size(20.dp))
+      Spacer(modifier = Modifier.size(8.dp))
+      TotalProgressRow(
+        totalDuration = viewState.totalDuration,
+        totalPlayedTime = viewState.totalPlayedTime,
+      )
+      Spacer(modifier = Modifier.size(16.dp))
       SliderRow(
         duration = viewState.duration,
         playedTime = viewState.playedTime,

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayView.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/BookPlayView.kt
@@ -107,6 +107,8 @@ private class BookPlayViewStatePreviewProvider : PreviewParameterProvider<BookPl
       cover = null,
       duration = 10.minutes,
       playedTime = 3.minutes,
+      totalDuration = 60.minutes,
+      totalPlayedTime = 13.minutes,
       playing = true,
       skipSilence = true,
       sleepTimerState = BookPlayViewState.SleepTimerViewState.Disabled,

--- a/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/TotalProgressRow.kt
+++ b/features/playbackScreen/src/main/kotlin/voice/features/playbackScreen/view/TotalProgressRow.kt
@@ -1,0 +1,60 @@
+package voice.features.playbackScreen.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import voice.core.strings.R
+import voice.core.ui.formatTime
+import kotlin.time.Duration
+
+@Composable
+internal fun TotalProgressRow(
+  totalDuration: Duration,
+  totalPlayedTime: Duration,
+) {
+  val totalDurationMs = totalDuration.inWholeMilliseconds
+  val totalPlayedMs = totalPlayedTime.inWholeMilliseconds
+
+  val progress = if (totalDurationMs > 0) {
+    (totalPlayedMs.toFloat() / totalDurationMs.toFloat()).coerceIn(0F, 1F)
+  } else {
+    0F
+  }
+
+  val percentComplete = (progress * 100).toInt()
+  val remainingTimeMs = (totalDurationMs - totalPlayedMs).coerceAtLeast(0L)
+  val remainingFormatted = formatTime(remainingTimeMs, remainingTimeMs)
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = stringResource(R.string.playback_total_progress_summary, percentComplete, remainingFormatted),
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+    LinearProgressIndicator(
+      progress = { progress },
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 8.dp)
+        .height(2.dp),
+      color = MaterialTheme.colorScheme.primary,
+      trackColor = MaterialTheme.colorScheme.surfaceVariant,
+    )
+  }
+}


### PR DESCRIPTION
# Description
- Introduces a new `TotalProgressRow` composable to display a non-interactive linear progress bar and a textual summary (e.g., "25% Complete • 7h 15m remaining").
- Updates `BookPlayViewState` to include `totalDuration` and `totalPlayedTime`.
- Maps the total progress data from the underlying `Book` model to the ViewState in `BookPlayViewModel`.
- Integrates the `TotalProgressRow` into the `BookPlayContent` beneath the chapter name for a clean, non-intrusive UI.

Resolves the following discussions: #3179 #3337 #3176

------

# Screenshots

<img width="1440" height="3004" alt="942aeac0-7a3a-44f5-bd3d-a73bdd0ad51b" src="https://github.com/user-attachments/assets/8c506653-f918-4370-848d-e2633bc0b937" />

