### PR TITLE
Feature: Add lockscreen seeking toggle

### DIFF
--- a/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
@@ -46,3 +46,6 @@ public annotation class DeveloperMenuUnlockedStore
 
 @Qualifier
 public annotation class FeatureFlagOverridesStore
+
+@Qualifier
+public annotation class LockscreenSeekingEnabledStore

--- a/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
@@ -204,6 +204,13 @@ public interface StoreModule {
       fileName = "featureFlagOverrides",
     )
   }
+
+  @Provides
+  @SingleIn(AppScope::class)
+  @LockscreenSeekingEnabledStore
+  private fun lockscreenSeekingEnabled(factory: VoiceDataStoreFactory): DataStore<Boolean> {
+    return factory.boolean("lockscreenSeekingEnabled", defaultValue = false)
+  }
 }
 
 private class LegacyDarkThemeMigration(

--- a/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
@@ -28,6 +28,7 @@ import voice.core.data.Book
 import voice.core.data.BookId
 import voice.core.data.repo.BookRepository
 import voice.core.data.store.CurrentBookStore
+import voice.core.data.store.LockscreenSeekingEnabledStore
 import voice.core.logging.api.Logger
 import voice.core.playback.player.VoicePlayer
 import voice.core.playback.session.search.BookSearchHandler
@@ -42,6 +43,8 @@ class LibrarySessionCallback(
   private val bookSearchHandler: BookSearchHandler,
   @CurrentBookStore
   private val currentBookStoreId: DataStore<BookId?>,
+  @LockscreenSeekingEnabledStore
+  private val lockscreenSeekingEnabledStore: DataStore<Boolean>,
   private val bookRepository: BookRepository,
 ) : MediaLibrarySession.Callback {
 
@@ -179,6 +182,20 @@ class LibrarySessionCallback(
       .buildUpon()
       .add(SessionCommand(CustomCommand.CUSTOM_COMMAND_ACTION, Bundle.EMPTY))
       .build()
+      
+    scope.launch {
+      lockscreenSeekingEnabledStore.data.collect { enabled ->
+        val playerCommands = if (enabled) {
+          connectionResult.availablePlayerCommands
+        } else {
+          connectionResult.availablePlayerCommands.buildUpon()
+            .remove(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+            .build()
+        }
+        session.setAvailableCommands(controller, sessionCommands, playerCommands)
+      }
+    }
+
     return ConnectionResult.accept(
       sessionCommands,
       connectionResult.availablePlayerCommands,

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -238,6 +238,8 @@
     <string name="settings.playback.auto_rewind.title">Auto rewind</string>
     <!-- Title for the setting that controls skip-forward and rewind duration. -->
     <string name="settings.playback.seek_time.title">Skip amount</string>
+    <string name="settings.playback.lockscreen_seeking.title">Allow seeking on lockscreen</string>
+    <string name="settings.playback.lockscreen_seeking.summary">When enabled, the timeline cursor is actionable on the lockscreen.</string>
     <!-- Settings support row for opening the FAQ. -->
     <string name="settings.support.faq.title">FAQ</string>
     <!-- Settings support row for getting help. -->

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
@@ -28,7 +28,7 @@ interface SettingsListener {
   fun toggleAnalytics()
   fun openFolderPicker()
   fun onAppVersionClick()
-
+  fun toggleLockscreenSeeking()
   fun openDeveloperMenu()
 
   companion object {
@@ -56,6 +56,7 @@ interface SettingsListener {
       override fun toggleAnalytics() {}
       override fun openFolderPicker() {}
       override fun onAppVersionClick() {}
+      override fun toggleLockscreenSeeking() {}
       override fun openDeveloperMenu() {}
     }
   }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ import voice.core.data.store.AnalyticsConsentStore
 import voice.core.data.store.AutoRewindAmountStore
 import voice.core.data.store.DeveloperMenuUnlockedStore
 import voice.core.data.store.GridModeStore
+import voice.core.data.store.LockscreenSeekingEnabledStore
 import voice.core.data.store.SeekTimeStore
 import voice.core.data.store.SleepTimerPreferenceStore
 import voice.core.data.store.ThemeColorSchemeStore
@@ -59,6 +60,8 @@ class SettingsViewModel(
   private val kioskModeFeatureFlag: FeatureFlag<Boolean>,
   @DeveloperMenuUnlockedStore
   private val developerMenuUnlockedStore: DataStore<Boolean>,
+  @LockscreenSeekingEnabledStore
+  private val lockscreenSeekingEnabledStore: DataStore<Boolean>,
   private val dynamicColorAvailability: DynamicColorAvailability,
   dispatcherProvider: DispatcherProvider,
 ) : SettingsListener {
@@ -84,6 +87,7 @@ class SettingsViewModel(
       kioskModeFeatureFlag.get()
     }
     val showDeveloperMenu by remember { developerMenuUnlockedStore.data }.collectAsState(initial = false)
+    val lockscreenSeekingEnabled by remember { lockscreenSeekingEnabledStore.data }.collectAsState(initial = false)
     val showThemeColorSchemePref = remember {
       dynamicColorAvailability.isSupported()
     }
@@ -110,6 +114,7 @@ class SettingsViewModel(
       showDeveloperMenu = showDeveloperMenu,
       showSupportDevelopment = appInfoProvider.supportDevelopmentIncluded,
       kioskMode = kioskMode,
+      lockscreenSeekingEnabled = lockscreenSeekingEnabled,
     )
   }
 
@@ -259,5 +264,11 @@ class SettingsViewModel(
 
   override fun openDeveloperMenu() {
     navigator.goTo(Destination.DeveloperSettings)
+  }
+
+  override fun toggleLockscreenSeeking() {
+    mainScope.launch {
+      lockscreenSeekingEnabledStore.updateData { !it }
+    }
   }
 }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsViewState.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsViewState.kt
@@ -19,6 +19,7 @@ data class SettingsViewState(
   val showDeveloperMenu: Boolean,
   val showSupportDevelopment: Boolean,
   val kioskMode: Boolean,
+  val lockscreenSeekingEnabled: Boolean,
 ) {
 
   enum class Dialog {
@@ -45,6 +46,7 @@ data class SettingsViewState(
         showDeveloperMenu = true,
         showSupportDevelopment = true,
         kioskMode = false,
+        lockscreenSeekingEnabled = false,
       )
     }
   }

--- a/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
@@ -160,6 +160,26 @@ private fun Settings(
       }
 
       item {
+        ListItem(
+          modifier = Modifier.clickable { listener.toggleLockscreenSeeking() },
+          leadingContent = {
+            Icon(
+              imageVector = VoiceIcons.LockOpen,
+              contentDescription = stringResource(StringsR.string.settings_playback_lockscreen_seeking_title),
+            )
+          },
+          headlineContent = { Text(stringResource(StringsR.string.settings_playback_lockscreen_seeking_title)) },
+          supportingContent = { Text(stringResource(StringsR.string.settings_playback_lockscreen_seeking_summary)) },
+          trailingContent = {
+            Switch(
+              checked = viewState.lockscreenSeekingEnabled,
+              onCheckedChange = { listener.toggleLockscreenSeeking() },
+            )
+          },
+        )
+      }
+
+      item {
         AutoSleepTimerCard(viewState.autoSleepTimer, listener)
       }
 

--- a/features/settings/src/test/kotlin/voice/features/settings/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/voice/features/settings/SettingsViewModelTest.kt
@@ -41,6 +41,7 @@ class SettingsViewModelTest {
   private val sleepTimerPreferenceStore = MemoryDataStore(SleepTimerPreference.Default)
   private val analyticsConsentStore = MemoryDataStore(false)
   private val developerMenuUnlockedStore = MemoryDataStore(false)
+  private val lockscreenSeekingEnabledStore = MemoryDataStore(false)
   private val navigator = mockk<Navigator> {
     every { goTo(any()) } just Runs
   }
@@ -71,6 +72,7 @@ class SettingsViewModelTest {
     gridCount = gridCount,
     kioskModeFeatureFlag = kioskModeFeatureFlag,
     developerMenuUnlockedStore = developerMenuUnlockedStore,
+    lockscreenSeekingEnabledStore = lockscreenSeekingEnabledStore,
     dynamicColorAvailability = dynamicColorAvailability,
     dispatcherProvider = DispatcherProvider(scope.coroutineContext, scope.coroutineContext, scope.coroutineContext),
   )


### PR DESCRIPTION
# Description
Adds a setting to enable/disable seeking via the lockscreen media session timeline cursor. By default, seeking on the lockscreen is disabled to prevent accidental seeks when the phone is in a pocket or when the screen is accidentally touched.

This resolves the feature request to make the lockscreen seek bar non-actionable or at least toggleable via a setting.

Closes #3229
Closes #3589

-----
# Screenshot
<img width="1440" height="2993" alt="e43eb9a7-f7bb-4e9f-98dc-e3622dfb09db" src="https://github.com/user-attachments/assets/5dff6365-6591-4203-80ee-1abed06c1ce0" />
