### PR TITLE
Add BookSource schema and playback resolver seam for remote sources

### DIFF
--- a/core/data/api/src/main/kotlin/voice/core/data/BookContent.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/BookContent.kt
@@ -28,6 +28,8 @@ public data class BookContent(
   val narrator: String?,
   val series: String?,
   val part: String?,
+  @ColumnInfo(defaultValue = "LOCAL")
+  val source: BookSource = BookSource.LOCAL,
 ) {
 
   @Ignore

--- a/core/data/api/src/main/kotlin/voice/core/data/BookSource.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/BookSource.kt
@@ -1,0 +1,6 @@
+package voice.core.data
+
+public enum class BookSource {
+  LOCAL,
+  AUDIOBOOKSHELF,
+}

--- a/core/data/api/src/main/kotlin/voice/core/data/playback/ChapterUriResolver.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/playback/ChapterUriResolver.kt
@@ -1,0 +1,13 @@
+package voice.core.data.playback
+
+import android.net.Uri
+import voice.core.data.BookContent
+import voice.core.data.Chapter
+
+public interface ChapterUriResolver {
+
+  public fun resolve(
+    chapter: Chapter,
+    content: BookContent,
+  ): Uri?
+}

--- a/core/data/api/src/main/kotlin/voice/core/data/playback/RemoteAuthHeaderProvider.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/playback/RemoteAuthHeaderProvider.kt
@@ -1,0 +1,8 @@
+package voice.core.data.playback
+
+import android.net.Uri
+
+public interface RemoteAuthHeaderProvider {
+
+  public fun headersFor(uri: Uri): Map<String, String>?
+}

--- a/core/data/api/src/main/kotlin/voice/core/data/repo/BookRepository.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/repo/BookRepository.kt
@@ -4,10 +4,13 @@ import kotlinx.coroutines.flow.Flow
 import voice.core.data.Book
 import voice.core.data.BookContent
 import voice.core.data.BookId
+import voice.core.data.BookSource
 
 public interface BookRepository {
 
   public fun flow(): Flow<List<Book>>
+
+  public fun flow(source: BookSource): Flow<List<Book>>
 
   public suspend fun all(): List<Book>
 

--- a/core/data/impl/src/main/kotlin/voice/core/data/repo/BookRepositoryImpl.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/repo/BookRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.sync.withLock
 import voice.core.data.Book
 import voice.core.data.BookContent
 import voice.core.data.BookId
+import voice.core.data.BookSource
 import voice.core.logging.api.Logger
 
 @SingleIn(AppScope::class)
@@ -38,6 +39,16 @@ public class BookRepositoryImpl(
     return contentRepo.flow()
       .map { contents ->
         contents.filter { it.isActive }
+          .mapNotNull { content ->
+            content.book()
+          }
+      }
+  }
+
+  override fun flow(source: BookSource): Flow<List<Book>> {
+    return contentRepo.flow()
+      .map { contents ->
+        contents.filter { it.isActive && it.source == source }
           .mapNotNull { content ->
             content.book()
           }

--- a/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/AppDb.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/AppDb.kt
@@ -32,6 +32,7 @@ import voice.core.data.repo.internals.migrations.Migration56
     AutoMigration(from = 56, to = 57, spec = Migration56::class),
     AutoMigration(from = 57, to = 58),
     AutoMigration(from = 58, to = 59),
+    AutoMigration(from = 59, to = 60),
   ],
 )
 @TypeConverters(Converters::class)
@@ -44,7 +45,7 @@ public abstract class AppDb : RoomDatabase() {
   public abstract fun recentBookSearchDao(): RecentBookSearchDao
 
   internal companion object {
-    const val VERSION = 59
+    const val VERSION = 60
     const val DATABASE_NAME = "autoBookDB"
   }
 }

--- a/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/Converters.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/Converters.kt
@@ -6,6 +6,7 @@ import androidx.room.TypeConverter
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import voice.core.data.BookId
+import voice.core.data.BookSource
 import voice.core.data.Bookmark
 import voice.core.data.ChapterId
 import voice.core.data.MarkData
@@ -78,4 +79,10 @@ internal class Converters {
 
   @TypeConverter
   fun fromBookmarkId(id: Bookmark.Id): String = id.value.toString()
+
+  @TypeConverter
+  fun toBookSource(value: String): BookSource = BookSource.valueOf(value)
+
+  @TypeConverter
+  fun fromBookSource(source: BookSource): String = source.name
 }

--- a/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/LocalChapterUriResolver.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/repo/internals/LocalChapterUriResolver.kt
@@ -1,0 +1,22 @@
+package voice.core.data.repo.internals
+
+import android.net.Uri
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import voice.core.data.BookContent
+import voice.core.data.BookSource
+import voice.core.data.Chapter
+import voice.core.data.playback.ChapterUriResolver
+import voice.core.data.toUri
+
+@ContributesIntoSet(AppScope::class)
+internal class LocalChapterUriResolver : ChapterUriResolver {
+
+  override fun resolve(
+    chapter: Chapter,
+    content: BookContent,
+  ): Uri? {
+    if (content.source != BookSource.LOCAL) return null
+    return chapter.id.toUri()
+  }
+}

--- a/core/data/impl/src/test/kotlin/voice/core/data/repo/internals/ConvertersTest.kt
+++ b/core/data/impl/src/test/kotlin/voice/core/data/repo/internals/ConvertersTest.kt
@@ -1,5 +1,6 @@
 package voice.core.data.repo.internals
 
+import voice.core.data.BookSource
 import voice.core.data.MarkData
 import java.io.File
 import java.time.Instant
@@ -12,6 +13,13 @@ class ConvertersTest {
   @Test
   fun instant() {
     test(Instant.now(), Converters::fromInstant, Converters::toInstant)
+  }
+
+  @Test
+  fun bookSource() {
+    BookSource.entries.forEach { source ->
+      test(source, Converters::fromBookSource, Converters::toBookSource)
+    }
   }
 
   @Test

--- a/core/data/impl/src/test/kotlin/voice/core/data/repo/internals/LocalChapterUriResolverTest.kt
+++ b/core/data/impl/src/test/kotlin/voice/core/data/repo/internals/LocalChapterUriResolverTest.kt
@@ -1,0 +1,68 @@
+package voice.core.data.repo.internals
+
+import voice.core.data.BookContent
+import voice.core.data.BookId
+import voice.core.data.BookSource
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.toUri
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalChapterUriResolverTest {
+
+  private val resolver = LocalChapterUriResolver()
+
+  @Test
+  fun `resolves local chapters to their id uri`() {
+    val chapter = chapter(id = ChapterId("content://tree/local/chapter1"))
+    val content = bookContent(source = BookSource.LOCAL)
+
+    assertEquals(chapter.id.toUri(), resolver.resolve(chapter, content))
+  }
+
+  @Test
+  fun `defers to other resolvers for non-local chapters`() {
+    val chapter = chapter(id = ChapterId("voice-abs://server/item/track/0"))
+    val content = bookContent(source = BookSource.AUDIOBOOKSHELF)
+
+    assertNull(resolver.resolve(chapter, content))
+  }
+
+  private fun chapter(id: ChapterId): Chapter {
+    return Chapter(
+      id = id,
+      name = "chapter",
+      duration = 1000,
+      fileLastModified = Instant.EPOCH,
+      fileSize = 0,
+      markData = emptyList(),
+    )
+  }
+
+  private fun bookContent(source: BookSource): BookContent {
+    val chapterId = ChapterId("content://tree/local/chapter1")
+    return BookContent(
+      id = BookId("book1"),
+      playbackSpeed = 1F,
+      skipSilence = false,
+      isActive = true,
+      lastPlayedAt = Instant.EPOCH,
+      author = null,
+      name = "book",
+      addedAt = Instant.EPOCH,
+      chapters = listOf(chapterId),
+      currentChapter = chapterId,
+      positionInChapter = 0,
+      cover = null,
+      gain = 0F,
+      genre = null,
+      narrator = null,
+      series = null,
+      part = null,
+      source = source,
+    )
+  }
+}

--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -18,6 +18,7 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import voice.core.data.playback.RemoteAuthHeaderProvider
 import voice.core.featureflag.FeatureFlag
 import voice.core.featureflag.Media3AudioOffloadFeatureFlagQualifier
 import voice.core.playback.misc.VolumeGain
@@ -28,6 +29,7 @@ import voice.core.playback.player.VoicePlayer
 import voice.core.playback.player.onAudioSessionIdChanged
 import voice.core.playback.playstate.PlayStateDelegatingListener
 import voice.core.playback.playstate.PositionUpdater
+import voice.core.playback.session.HeaderInjectingHttpDataSourceFactory
 import voice.core.playback.session.LibrarySessionCallback
 import voice.core.playback.session.PlaybackService
 import voice.core.strings.R as StringsR
@@ -37,8 +39,12 @@ interface PlaybackModule {
 
   @Provides
   @SingleIn(PlaybackScope::class)
-  fun mediaSourceFactory(context: Context): MediaSource.Factory {
-    val dataSourceFactory = DefaultDataSource.Factory(context)
+  fun mediaSourceFactory(
+    context: Context,
+    remoteAuthHeaderProviders: Set<@JvmSuppressWildcards RemoteAuthHeaderProvider>,
+  ): MediaSource.Factory {
+    val httpDataSourceFactory = HeaderInjectingHttpDataSourceFactory(remoteAuthHeaderProviders)
+    val dataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
     val extractorsFactory = DefaultExtractorsFactory()
       .setConstantBitrateSeekingEnabled(true)
     return DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)

--- a/core/playback/src/main/kotlin/voice/core/playback/session/HeaderInjectingHttpDataSourceFactory.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/HeaderInjectingHttpDataSourceFactory.kt
@@ -1,0 +1,33 @@
+package voice.core.playback.session
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.HttpDataSource
+import voice.core.data.playback.RemoteAuthHeaderProvider
+
+@UnstableApi
+internal class HeaderInjectingHttpDataSourceFactory(
+  private val headerProviders: Set<@JvmSuppressWildcards RemoteAuthHeaderProvider>,
+) : DataSource.Factory {
+
+  private val delegateFactory = DefaultHttpDataSource.Factory()
+
+  override fun createDataSource(): DataSource {
+    return HeaderInjectingDataSource(delegateFactory.createDataSource(), headerProviders)
+  }
+}
+
+@UnstableApi
+private class HeaderInjectingDataSource(
+  private val delegate: HttpDataSource,
+  private val headerProviders: Set<RemoteAuthHeaderProvider>,
+) : DataSource by delegate {
+
+  override fun open(dataSpec: DataSpec): Long {
+    val headers = headerProviders.firstNotNullOfOrNull { it.headersFor(dataSpec.uri) }
+    val spec = if (headers.isNullOrEmpty()) dataSpec else dataSpec.withAdditionalHeaders(headers)
+    return delegate.open(spec)
+  }
+}

--- a/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
@@ -16,6 +16,7 @@ import voice.core.data.BookContent
 import voice.core.data.BookId
 import voice.core.data.Chapter
 import voice.core.data.durationMs
+import voice.core.data.playback.ChapterUriResolver
 import voice.core.data.repo.BookContentRepo
 import voice.core.data.repo.BookRepository
 import voice.core.data.repo.ChapterRepo
@@ -31,9 +32,14 @@ class MediaItemProvider(
   private val chapterRepo: ChapterRepo,
   private val contentRepo: BookContentRepo,
   private val imageFileProvider: ImageFileProvider,
+  private val chapterUriResolvers: Set<@JvmSuppressWildcards ChapterUriResolver>,
   @CurrentBookStore
   private val currentBookStoreId: DataStore<BookId?>,
 ) {
+
+  private fun Chapter.resolveUri(content: BookContent): Uri {
+    return chapterUriResolvers.firstNotNullOfOrNull { it.resolve(this, content) } ?: id.toUri()
+  }
 
   fun root(): MediaItem = MediaItem(
     title = application.getString(StringsR.string.media_session_library_root),
@@ -149,7 +155,7 @@ class MediaItemProvider(
     mediaId = MediaId.Chapter(bookId = content.id, chapterId = chapter.id),
     browsable = false,
     isPlayable = true,
-    sourceUri = chapter.id.toUri(),
+    sourceUri = chapter.resolveUri(content),
     imageUri = content.cover?.toProvidedUri(),
     artist = content.author,
     mediaType = MediaType.AudioBookChapter,
@@ -165,7 +171,7 @@ class MediaItemProvider(
     mediaId = playbackItem.mediaId,
     browsable = false,
     isPlayable = true,
-    sourceUri = playbackItem.chapter.id.toUri(),
+    sourceUri = playbackItem.chapter.resolveUri(content),
     imageUri = content.cover?.toProvidedUri(),
     artist = content.author,
     durationMs = playbackItem.mark.durationMs,

--- a/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
@@ -27,6 +27,7 @@ import voice.core.data.Chapter
 import voice.core.data.ChapterId
 import voice.core.data.ChapterMark
 import voice.core.data.MarkData
+import voice.core.data.playback.ChapterUriResolver
 import voice.core.logging.api.LogWriter
 import voice.core.logging.api.Logger
 import voice.core.playback.MemoryDataStore
@@ -90,7 +91,7 @@ class VoicePlayerTest {
     .build()
 
   private val scope = TestScope()
-  private val mediaItemProvider = MediaItemProvider(mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+  private val mediaItemProvider = MediaItemProvider(mockk(), mockk(), mockk(), mockk(), mockk(), emptySet<ChapterUriResolver>(), mockk())
   private val bookId = BookId(Uuid.random().toString())
   private lateinit var currentBook: Book
   private val sleepTimer = FakeSleepTimer()

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/overview/BookOverviewViewModel.kt
@@ -25,6 +25,7 @@ import voice.core.common.MainScope
 import voice.core.common.comparator.sortedNaturally
 import voice.core.data.Book
 import voice.core.data.BookId
+import voice.core.data.BookSource
 import voice.core.data.GridMode
 import voice.core.data.KioskModeDemoData
 import voice.core.data.repo.BookContentRepo
@@ -98,7 +99,7 @@ class BookOverviewViewModel(
       .collectAsState(initial = PlayStateManager.PlayState.Paused).value
     val hasStoragePermissionBug = remember { deviceHasStoragePermissionBug.hasBug }
       .collectAsState().value
-    val books = remember { repo.flow() }
+    val books = remember { repo.flow(BookSource.LOCAL) }
       .collectAsState(initial = emptyList()).value
     val currentBookId = remember { currentBookStoreDataStore.data }
       .collectAsState(initial = null).value


### PR DESCRIPTION
Lays the groundwork for playing audiobooks from a remote server (Audiobookshelf) alongside local folders:

- BookContent gets a `source` column (LOCAL/AUDIOBOOKSHELF) so the two libraries can be queried separately; BookOverviewViewModel now scopes to LOCAL only.
- ChapterUriResolver and RemoteAuthHeaderProvider seams let a future remote-source module plug playback URIs and auth headers into MediaItemProvider/PlaybackModule without core:playback depending on it.
- LocalChapterUriResolver preserves today's local playback behavior unchanged.