### PR TITLE
Customizable buttons to the playback notification

### DIFF
--- a/core/data/api/src/main/kotlin/voice/core/data/notification/MediaNotificationPreferences.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/notification/MediaNotificationPreferences.kt
@@ -1,0 +1,30 @@
+package voice.core.data.notification
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public enum class NotificationAction {
+  REWIND,
+  FAST_FORWARD,
+  NEXT_CHAPTER,
+  PREVIOUS_CHAPTER,
+  SLEEP_TIMER,
+  SKIP_SILENCE,
+  BOOKMARK,
+}
+
+@Serializable
+public data class MediaNotificationPreferences(
+  val slot1: NotificationAction,
+  val slot2: NotificationAction,
+  val slot3: NotificationAction,
+) {
+
+  public companion object {
+    public val Default: MediaNotificationPreferences = MediaNotificationPreferences(
+      slot1 = NotificationAction.REWIND,
+      slot2 = NotificationAction.FAST_FORWARD,
+      slot3 = NotificationAction.SLEEP_TIMER,
+    )
+  }
+}

--- a/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
+++ b/core/data/api/src/main/kotlin/voice/core/data/store/StoreQualifiers.kt
@@ -46,3 +46,6 @@ public annotation class DeveloperMenuUnlockedStore
 
 @Qualifier
 public annotation class FeatureFlagOverridesStore
+
+@Qualifier
+public annotation class MediaNotificationPreferencesStore

--- a/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
+++ b/core/data/impl/src/main/kotlin/voice/core/data/store/StoreModule.kt
@@ -17,6 +17,7 @@ import voice.core.data.BookId
 import voice.core.data.GridMode
 import voice.core.data.ThemeColorScheme
 import voice.core.data.ThemeMode
+import voice.core.data.notification.MediaNotificationPreferences
 import voice.core.data.sleeptimer.SleepTimerPreference
 import voice.core.featureflag.FeatureFlagOverride
 import java.io.File
@@ -111,6 +112,17 @@ public interface StoreModule {
       serializer = SleepTimerPreference.Companion.serializer(),
       fileName = "sleepTime3",
       defaultValue = SleepTimerPreference.Default,
+    )
+  }
+
+  @Provides
+  @SingleIn(AppScope::class)
+  @MediaNotificationPreferencesStore
+  private fun mediaNotificationPreferences(factory: VoiceDataStoreFactory): DataStore<MediaNotificationPreferences> {
+    return factory.create(
+      serializer = MediaNotificationPreferences.Companion.serializer(),
+      fileName = "mediaNotificationPreferences",
+      defaultValue = MediaNotificationPreferences.Default,
     )
   }
 

--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -10,7 +10,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
-import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaLibraryService
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
@@ -29,8 +28,8 @@ import voice.core.playback.player.onAudioSessionIdChanged
 import voice.core.playback.playstate.PlayStateDelegatingListener
 import voice.core.playback.playstate.PositionUpdater
 import voice.core.playback.session.LibrarySessionCallback
+import voice.core.playback.session.MediaButtonPreferencesUpdater
 import voice.core.playback.session.PlaybackService
-import voice.core.strings.R as StringsR
 
 @ContributesTo(PlaybackScope::class)
 interface PlaybackModule {
@@ -99,24 +98,14 @@ interface PlaybackModule {
     player: VoicePlayer,
     callback: LibrarySessionCallback,
     mainActivityIntentProvider: MainActivityIntentProvider,
-    context: Context,
+    mediaButtonPreferencesUpdater: MediaButtonPreferencesUpdater,
   ): MediaLibraryService.MediaLibrarySession {
     return MediaLibraryService.MediaLibrarySession.Builder(service, player, callback)
       .setSessionActivity(mainActivityIntentProvider.toCurrentBook())
-      .setMediaButtonPreferences(
-        listOf(
-          CommandButton.Builder(CommandButton.ICON_SKIP_BACK)
-            .setDisplayName(context.getString(StringsR.string.playback_action_rewind))
-            .setPlayerCommand(Player.COMMAND_SEEK_BACK)
-            .setSlots(CommandButton.SLOT_BACK)
-            .build(),
-          CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD)
-            .setDisplayName(context.getString(StringsR.string.playback_action_fast_forward))
-            .setPlayerCommand(Player.COMMAND_SEEK_FORWARD)
-            .setSlots(CommandButton.SLOT_FORWARD)
-            .build(),
-        ),
-      )
+      .setMediaButtonPreferences(mediaButtonPreferencesUpdater.preferences())
       .build()
+      .also { session ->
+        mediaButtonPreferencesUpdater.attachTo(session)
+      }
   }
 }

--- a/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
@@ -27,11 +27,16 @@ import kotlinx.coroutines.launch
 import voice.core.data.Book
 import voice.core.data.BookId
 import voice.core.data.repo.BookRepository
+import voice.core.data.repo.BookmarkRepo
+import voice.core.data.sleeptimer.SleepTimerPreference
 import voice.core.data.store.CurrentBookStore
+import voice.core.data.store.SleepTimerPreferenceStore
 import voice.core.logging.api.Logger
 import voice.core.playback.player.VoicePlayer
 import voice.core.playback.session.search.BookSearchHandler
 import voice.core.playback.session.search.BookSearchParser
+import voice.core.sleeptimer.SleepTimer
+import voice.core.sleeptimer.SleepTimerMode
 
 @Inject
 class LibrarySessionCallback(
@@ -43,7 +48,27 @@ class LibrarySessionCallback(
   @CurrentBookStore
   private val currentBookStoreId: DataStore<BookId?>,
   private val bookRepository: BookRepository,
+  private val bookmarkRepo: BookmarkRepo,
+  private val sleepTimer: SleepTimer,
+  @SleepTimerPreferenceStore
+  private val sleepTimerPreferenceStore: DataStore<SleepTimerPreference>,
 ) : MediaLibrarySession.Callback {
+
+  companion object {
+    const val ACTION_SLEEP_TIMER = "voice.playback.action.SLEEP_TIMER"
+    const val ACTION_NEXT_CHAPTER = "voice.playback.action.NEXT_CHAPTER"
+    const val ACTION_PREVIOUS_CHAPTER = "voice.playback.action.PREVIOUS_CHAPTER"
+    const val ACTION_SKIP_SILENCE = "voice.playback.action.SKIP_SILENCE"
+    const val ACTION_BOOKMARK = "voice.playback.action.BOOKMARK"
+
+    private val NOTIFICATION_ACTIONS = setOf(
+      ACTION_SLEEP_TIMER,
+      ACTION_NEXT_CHAPTER,
+      ACTION_PREVIOUS_CHAPTER,
+      ACTION_SKIP_SILENCE,
+      ACTION_BOOKMARK,
+    )
+  }
 
   override fun onAddMediaItems(
     mediaSession: MediaSession,
@@ -178,6 +203,11 @@ class LibrarySessionCallback(
     val sessionCommands = connectionResult.availableSessionCommands
       .buildUpon()
       .add(SessionCommand(CustomCommand.CUSTOM_COMMAND_ACTION, Bundle.EMPTY))
+      .apply {
+        NOTIFICATION_ACTIONS.forEach { action ->
+          add(SessionCommand(action, Bundle.EMPTY))
+        }
+      }
       .build()
     return ConnectionResult.accept(
       sessionCommands,
@@ -199,23 +229,55 @@ class LibrarySessionCallback(
     customCommand: SessionCommand,
     args: Bundle,
   ): ListenableFuture<SessionResult> {
-    val command = CustomCommand.parse(customCommand, args)
-      ?: return super.onCustomCommand(session, controller, customCommand, args)
-    when (command) {
-      CustomCommand.ForceSeekToNext -> {
-        player.forceSeekToNext()
-      }
-      CustomCommand.ForceSeekToPrevious -> {
-        player.forceSeekToPrevious()
-      }
-      is CustomCommand.SetSkipSilence -> {
-        player.setSkipSilenceEnabled(command.skipSilence)
-      }
-      is CustomCommand.SetGain -> {
-        player.setGain(command.gain)
+    when (customCommand.customAction) {
+      ACTION_SLEEP_TIMER -> scope.launch { toggleSleepTimer() }
+      ACTION_NEXT_CHAPTER -> player.forceSeekToNext()
+      ACTION_PREVIOUS_CHAPTER -> player.forceSeekToPrevious()
+      ACTION_SKIP_SILENCE -> scope.launch { toggleSkipSilence() }
+      ACTION_BOOKMARK -> scope.launch { addBookmarkAtCurrentPosition() }
+      else -> {
+        val command = CustomCommand.parse(customCommand, args)
+          ?: return super.onCustomCommand(session, controller, customCommand, args)
+        when (command) {
+          CustomCommand.ForceSeekToNext -> {
+            player.forceSeekToNext()
+          }
+          CustomCommand.ForceSeekToPrevious -> {
+            player.forceSeekToPrevious()
+          }
+          is CustomCommand.SetSkipSilence -> {
+            player.setSkipSilenceEnabled(command.skipSilence)
+          }
+          is CustomCommand.SetGain -> {
+            player.setGain(command.gain)
+          }
+        }
       }
     }
 
     return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+  }
+
+  private suspend fun toggleSleepTimer() {
+    if (sleepTimer.state.value.enabled) {
+      sleepTimer.disable()
+    } else {
+      val duration = sleepTimerPreferenceStore.data.first().duration
+      sleepTimer.enable(SleepTimerMode.TimedWithDuration(duration))
+    }
+  }
+
+  private suspend fun toggleSkipSilence() {
+    val book = currentBook() ?: return
+    player.setSkipSilenceEnabled(!book.content.skipSilence)
+  }
+
+  private suspend fun addBookmarkAtCurrentPosition() {
+    val book = currentBook() ?: return
+    bookmarkRepo.addBookmarkAtBookPosition(
+      book = book,
+      title = null,
+      setBySleepTimer = false,
+    )
   }
 }

--- a/core/playback/src/main/kotlin/voice/core/playback/session/MediaButtonPreferencesUpdater.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/MediaButtonPreferencesUpdater.kt
@@ -1,0 +1,90 @@
+package voice.core.playback.session
+
+import android.content.Context
+import android.os.Bundle
+import androidx.datastore.core.DataStore
+import androidx.media3.common.Player
+import androidx.media3.session.CommandButton
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
+import androidx.media3.session.SessionCommand
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import voice.core.data.notification.MediaNotificationPreferences
+import voice.core.data.notification.NotificationAction
+import voice.core.data.store.MediaNotificationPreferencesStore
+import voice.core.playback.R
+import voice.core.playback.di.PlaybackScope
+import voice.core.sleeptimer.SleepTimer
+import voice.core.sleeptimer.SleepTimerState
+import voice.core.strings.R as StringsR
+
+@Inject
+@SingleIn(PlaybackScope::class)
+class MediaButtonPreferencesUpdater(
+  private val context: Context,
+  private val scope: CoroutineScope,
+  private val sleepTimer: SleepTimer,
+  @MediaNotificationPreferencesStore
+  private val preferencesStore: DataStore<MediaNotificationPreferences>,
+) {
+
+  fun attachTo(session: MediaLibrarySession) {
+    scope.launch {
+      combine(preferencesStore.data, sleepTimer.state, ::preferences).collect { buttons ->
+        session.setMediaButtonPreferences(buttons)
+      }
+    }
+  }
+
+  fun preferences(
+    preferences: MediaNotificationPreferences = MediaNotificationPreferences.Default,
+    sleepTimerState: SleepTimerState = sleepTimer.state.value,
+  ): List<CommandButton> = listOf(
+    commandButton(preferences.slot1, sleepTimerState, CommandButton.SLOT_BACK),
+    commandButton(preferences.slot2, sleepTimerState, CommandButton.SLOT_FORWARD),
+    commandButton(preferences.slot3, sleepTimerState, slot = null),
+  )
+
+  private fun commandButton(
+    action: NotificationAction,
+    sleepTimerState: SleepTimerState,
+    slot: Int?,
+  ): CommandButton {
+    val builder = when (action) {
+      NotificationAction.REWIND ->
+        CommandButton.Builder(CommandButton.ICON_SKIP_BACK)
+          .setDisplayName(context.getString(StringsR.string.playback_action_rewind))
+          .setPlayerCommand(Player.COMMAND_SEEK_BACK)
+      NotificationAction.FAST_FORWARD ->
+        CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD)
+          .setDisplayName(context.getString(StringsR.string.playback_action_fast_forward))
+          .setPlayerCommand(Player.COMMAND_SEEK_FORWARD)
+      NotificationAction.NEXT_CHAPTER ->
+        CommandButton.Builder(CommandButton.ICON_NEXT)
+          .setDisplayName(context.getString(StringsR.string.playback_chapter_next))
+          .setSessionCommand(SessionCommand(LibrarySessionCallback.ACTION_NEXT_CHAPTER, Bundle.EMPTY))
+      NotificationAction.PREVIOUS_CHAPTER ->
+        CommandButton.Builder(CommandButton.ICON_PREVIOUS)
+          .setDisplayName(context.getString(StringsR.string.playback_chapter_previous))
+          .setSessionCommand(SessionCommand(LibrarySessionCallback.ACTION_PREVIOUS_CHAPTER, Bundle.EMPTY))
+      NotificationAction.SLEEP_TIMER ->
+        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+          .setCustomIconResId(if (sleepTimerState.enabled) R.drawable.ic_sleep_timer_off else R.drawable.ic_sleep_timer)
+          .setDisplayName(context.getString(StringsR.string.sleep_timer_action_open))
+          .setSessionCommand(SessionCommand(LibrarySessionCallback.ACTION_SLEEP_TIMER, Bundle.EMPTY))
+      NotificationAction.SKIP_SILENCE ->
+        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+          .setCustomIconResId(R.drawable.ic_skip_silence)
+          .setDisplayName(context.getString(StringsR.string.playback_option_skip_silence))
+          .setSessionCommand(SessionCommand(LibrarySessionCallback.ACTION_SKIP_SILENCE, Bundle.EMPTY))
+      NotificationAction.BOOKMARK ->
+        CommandButton.Builder(CommandButton.ICON_BOOKMARK_FILLED)
+          .setDisplayName(context.getString(StringsR.string.bookmark_title))
+          .setSessionCommand(SessionCommand(LibrarySessionCallback.ACTION_BOOKMARK, Bundle.EMPTY))
+    }
+    return (if (slot != null) builder.setSlots(slot) else builder).build()
+  }
+}

--- a/core/playback/src/main/res/drawable/ic_skip_silence.xml
+++ b/core/playback/src/main/res/drawable/ic_skip_silence.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+  android:tint="?attr/colorControlNormal">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M3,9h2v6H3ZM7,7h2v10H7ZM11,4h2v16H11ZM15,7h2v10H15ZM19,9h2v6H19Z" />
+</vector>

--- a/core/playback/src/main/res/drawable/ic_sleep_timer.xml
+++ b/core/playback/src/main/res/drawable/ic_sleep_timer.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+  android:tint="?attr/colorControlNormal">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M12.1,22Q10,22 8.16,21.2Q6.33,20.4 4.96,19.04T2.8,15.84T2,11.9Q2,8.25 4.33,5.46T10.25,2Q9.8,4.47 10.53,6.84t2.5,4.14t4.14,2.5T22,13.75q-0.65,3.6 -3.45,5.93T12.1,22Zm0,-2q2.2,0 4.07,-1.1t2.95,-3.02q-2.15,-0.2 -4.07,-1.09T11.6,12.38T9.18,8.92T8.1,4.85Q6.18,5.93 5.09,7.81T4,11.9q0,3.38 2.36,5.74T12.1,20Z" />
+</vector>

--- a/core/playback/src/main/res/drawable/ic_sleep_timer_off.xml
+++ b/core/playback/src/main/res/drawable/ic_sleep_timer_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+  android:tint="?attr/colorControlNormal">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M19.15,19.13L17.73,17.7q0.43,-0.4 0.77,-0.86q0.35,-0.46 0.63,-0.96q-1.2,-0.13 -2.35,-0.45t-2.2,-0.88L9.4,9.38Q8.85,8.32 8.53,7.19T8.1,4.85Q7.6,5.13 7.14,5.47T6.28,6.25L4.88,4.85Q5.95,3.75 7.31,3.02T10.25,2Q9.8,4.47 10.53,6.84t2.5,4.14t4.14,2.5T22,13.75q-0.27,1.57 -1.01,2.94t-1.84,2.44Zm-0.78,4.93l-2.7,-2.7q-0.85,0.32 -1.74,0.49T12.1,22Q10,22 8.16,21.2Q6.33,20.4 4.96,19.04T2.8,15.84T2,11.9Q2,10.95 2.16,10.06Q2.33,9.17 2.65,8.32L-0.03,5.65L1.4,4.22l18.4,18.4l-1.43,1.43ZM12.1,20q0.5,0 1,-0.06t0.97,-0.19L4.25,9.92q-0.13,0.5 -0.19,0.99T4,11.9q0,3.38 2.36,5.74T12.1,20Z" />
+</vector>

--- a/core/playback/src/test/kotlin/voice/core/playback/session/LibrarySessionCallbackTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/session/LibrarySessionCallbackTest.kt
@@ -1,0 +1,164 @@
+package voice.core.playback.session
+
+import android.os.Bundle
+import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import voice.core.data.Book
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.repo.BookRepository
+import voice.core.data.repo.BookmarkRepo
+import voice.core.data.sleeptimer.SleepTimerPreference
+import voice.core.playback.MemoryDataStore
+import voice.core.playback.player.VoicePlayer
+import voice.core.playback.session.search.BookSearchHandler
+import voice.core.playback.session.search.BookSearchParser
+import voice.core.playback.session.search.book
+import voice.core.sleeptimer.SleepTimer
+import voice.core.sleeptimer.SleepTimerMode
+import voice.core.sleeptimer.SleepTimerState
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
+
+@RunWith(AndroidJUnit4::class)
+class LibrarySessionCallbackTest {
+
+  private val sleepTimer = FakeSleepTimer()
+  private val sleepTimerPreferenceStore = MemoryDataStore(
+    SleepTimerPreference.Default.copy(duration = 15.minutes),
+  )
+  private val player = mockk<VoicePlayer>(relaxed = true)
+  private val bookRepository = mockk<BookRepository>(relaxed = true)
+  private val bookmarkRepo = mockk<BookmarkRepo>(relaxed = true)
+  private var currentBook: Book? = null
+
+  private fun callback(scope: TestScope) = LibrarySessionCallback(
+    mediaItemProvider = mockk(relaxed = true),
+    scope = scope,
+    player = player,
+    bookSearchParser = mockk<BookSearchParser>(relaxed = true),
+    bookSearchHandler = mockk<BookSearchHandler>(relaxed = true),
+    currentBookStoreId = MemoryDataStore(currentBook?.content?.id),
+    bookRepository = bookRepository,
+    bookmarkRepo = bookmarkRepo,
+    sleepTimer = sleepTimer,
+    sleepTimerPreferenceStore = sleepTimerPreferenceStore,
+  )
+
+  private fun sendCommand(
+    scope: TestScope,
+    action: String,
+  ) {
+    callback(scope).onCustomCommand(
+      mockk<MediaSession>(relaxed = true),
+      mockk<MediaSession.ControllerInfo>(relaxed = true),
+      SessionCommand(action, Bundle.EMPTY),
+      Bundle.EMPTY,
+    )
+  }
+
+  private fun chapter() = Chapter(
+    id = ChapterId(Uuid.random().toString()),
+    name = "chapter",
+    duration = 10_000,
+    fileLastModified = Instant.EPOCH,
+    markData = emptyList(),
+    fileSize = 0,
+  )
+
+  private fun setCurrentBook(book: Book) {
+    currentBook = book
+    coEvery { bookRepository.get(book.content.id) } returns book
+  }
+
+  @Test
+  fun `sleep timer action enables the timer with the stored duration when disabled`() = runTest {
+    sendCommand(this, LibrarySessionCallback.ACTION_SLEEP_TIMER)
+    advanceUntilIdle()
+
+    assertEquals(
+      expected = SleepTimerState.Enabled.WithDuration(15.minutes),
+      actual = sleepTimer.state.value,
+    )
+  }
+
+  @Test
+  fun `sleep timer action disables the timer when enabled`() = runTest {
+    sleepTimer.enable(SleepTimerMode.TimedWithDuration(15.minutes))
+    sendCommand(this, LibrarySessionCallback.ACTION_SLEEP_TIMER)
+    advanceUntilIdle()
+
+    assertEquals(expected = SleepTimerState.Disabled, actual = sleepTimer.state.value)
+  }
+
+  @Test
+  fun `next chapter action force seeks to next`() = runTest {
+    sendCommand(this, LibrarySessionCallback.ACTION_NEXT_CHAPTER)
+    advanceUntilIdle()
+
+    verify { player.forceSeekToNext() }
+  }
+
+  @Test
+  fun `previous chapter action force seeks to previous`() = runTest {
+    sendCommand(this, LibrarySessionCallback.ACTION_PREVIOUS_CHAPTER)
+    advanceUntilIdle()
+
+    verify { player.forceSeekToPrevious() }
+  }
+
+  @Test
+  fun `skip silence action enables skip silence when the current book has it disabled`() = runTest {
+    setCurrentBook(book(listOf(chapter())))
+    sendCommand(this, LibrarySessionCallback.ACTION_SKIP_SILENCE)
+    advanceUntilIdle()
+
+    verify { player.setSkipSilenceEnabled(true) }
+  }
+
+  @Test
+  fun `bookmark action adds a bookmark at the current book position`() = runTest {
+    val book = book(listOf(chapter()))
+    setCurrentBook(book)
+    sendCommand(this, LibrarySessionCallback.ACTION_BOOKMARK)
+    advanceUntilIdle()
+
+    coVerify {
+      bookmarkRepo.addBookmarkAtBookPosition(book = book, title = null, setBySleepTimer = false)
+    }
+  }
+
+  private class FakeSleepTimer : SleepTimer {
+    override val state: StateFlow<SleepTimerState>
+      get() = stateFlow
+
+    private val stateFlow = MutableStateFlow<SleepTimerState>(SleepTimerState.Disabled)
+
+    override fun enable(mode: SleepTimerMode) {
+      stateFlow.value = when (mode) {
+        is SleepTimerMode.TimedWithDuration -> SleepTimerState.Enabled.WithDuration(mode.duration)
+        SleepTimerMode.TimedWithDefault -> error("TimedWithDefault is not used in these tests")
+        SleepTimerMode.EndOfChapter -> SleepTimerState.Enabled.WithEndOfChapter
+      }
+    }
+
+    override fun disable() {
+      stateFlow.value = SleepTimerState.Disabled
+    }
+  }
+}

--- a/core/playback/src/test/kotlin/voice/core/playback/session/MediaButtonPreferencesUpdaterTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/session/MediaButtonPreferencesUpdaterTest.kt
@@ -1,0 +1,105 @@
+package voice.core.playback.session
+
+import androidx.media3.session.CommandButton
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.TestScope
+import org.junit.Test
+import org.junit.runner.RunWith
+import voice.core.data.notification.MediaNotificationPreferences
+import voice.core.data.notification.NotificationAction
+import voice.core.playback.MemoryDataStore
+import voice.core.playback.R
+import voice.core.sleeptimer.SleepTimer
+import voice.core.sleeptimer.SleepTimerMode
+import voice.core.sleeptimer.SleepTimerState
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+class MediaButtonPreferencesUpdaterTest {
+
+  private val sleepTimer = FakeSleepTimer()
+  private val preferencesStore = MemoryDataStore(MediaNotificationPreferences.Default)
+  private val updater = MediaButtonPreferencesUpdater(
+    context = ApplicationProvider.getApplicationContext(),
+    scope = TestScope(),
+    sleepTimer = sleepTimer,
+    preferencesStore = preferencesStore,
+  )
+
+  @Test
+  fun `sleep timer button uses the disabled icon when the timer is off`() {
+    val button = updater.preferences().sleepTimerButton()
+    assertEquals(expected = R.drawable.ic_sleep_timer, actual = button.iconResId)
+  }
+
+  @Test
+  fun `sleep timer button uses the enabled icon when the timer is running`() {
+    sleepTimer.enable(SleepTimerMode.TimedWithDuration(15.minutes))
+
+    val button = updater.preferences().sleepTimerButton()
+
+    assertEquals(expected = R.drawable.ic_sleep_timer_off, actual = button.iconResId)
+  }
+
+  @Test
+  fun `slot1 and slot2 default to rewind and fast forward in their fixed slots`() {
+    val buttons = updater.preferences()
+
+    assertEquals(expected = CommandButton.SLOT_BACK, actual = buttons[0].slots.get(0))
+    assertEquals(expected = CommandButton.SLOT_FORWARD, actual = buttons[1].slots.get(0))
+  }
+
+  @Test
+  fun `a bookmark action in slot3 renders as a bookmark command button`() {
+    val buttons = updater.preferences(
+      preferences = MediaNotificationPreferences.Default.copy(slot3 = NotificationAction.BOOKMARK),
+    )
+
+    val bookmarkButton = buttons[2]
+    assertEquals(
+      expected = LibrarySessionCallback.ACTION_BOOKMARK,
+      actual = bookmarkButton.sessionCommand?.customAction,
+    )
+  }
+
+  @Test
+  fun `next and previous chapter actions dispatch their dedicated session commands`() {
+    val buttons = updater.preferences(
+      preferences = MediaNotificationPreferences(
+        slot1 = NotificationAction.NEXT_CHAPTER,
+        slot2 = NotificationAction.PREVIOUS_CHAPTER,
+        slot3 = NotificationAction.SLEEP_TIMER,
+      ),
+    )
+
+    assertEquals(expected = LibrarySessionCallback.ACTION_NEXT_CHAPTER, actual = buttons[0].sessionCommand?.customAction)
+    assertEquals(expected = LibrarySessionCallback.ACTION_PREVIOUS_CHAPTER, actual = buttons[1].sessionCommand?.customAction)
+  }
+
+  private fun List<CommandButton>.sleepTimerButton() = single {
+    it.sessionCommand?.customAction == LibrarySessionCallback.ACTION_SLEEP_TIMER
+  }
+
+  private class FakeSleepTimer : SleepTimer {
+    override val state: StateFlow<SleepTimerState>
+      get() = stateFlow
+
+    private val stateFlow = MutableStateFlow<SleepTimerState>(SleepTimerState.Disabled)
+
+    override fun enable(mode: SleepTimerMode) {
+      stateFlow.value = when (mode) {
+        is SleepTimerMode.TimedWithDuration -> SleepTimerState.Enabled.WithDuration(mode.duration)
+        SleepTimerMode.TimedWithDefault -> error("TimedWithDefault is not used in these tests")
+        SleepTimerMode.EndOfChapter -> SleepTimerState.Enabled.WithEndOfChapter
+      }
+    }
+
+    override fun disable() {
+      stateFlow.value = SleepTimerState.Disabled
+    }
+  }
+}

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -234,6 +234,12 @@
     <string name="settings.library.folders.summary">Manage folders scanned for audiobooks</string>
     <!-- Settings row for toggling grid layout in the library. -->
     <string name="settings.library.use_grid.title">Use grid layout</string>
+    <!-- Label for one of the three configurable notification button slots, %1$d is 1, 2 or 3. -->
+    <string name="settings.media_notification.button_label">Button %1$d</string>
+    <!-- Settings row summary explaining the notification button customization screen. -->
+    <string name="settings.media_notification.summary">Choose which actions appear in the playback notification</string>
+    <!-- Settings row and screen title for customizing the playback notification buttons. -->
+    <string name="settings.media_notification.title">Notification buttons</string>
     <!-- Title for the setting that rewinds automatically when playback resumes. -->
     <string name="settings.playback.auto_rewind.title">Auto rewind</string>
     <!-- Title for the setting that controls skip-forward and rewind duration. -->

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsListener.kt
@@ -30,6 +30,7 @@ interface SettingsListener {
   fun onAppVersionClick()
 
   fun openDeveloperMenu()
+  fun openMediaNotificationSettings()
 
   companion object {
     fun noop() = object : SettingsListener {
@@ -57,6 +58,7 @@ interface SettingsListener {
       override fun openFolderPicker() {}
       override fun onAppVersionClick() {}
       override fun openDeveloperMenu() {}
+      override fun openMediaNotificationSettings() {}
     }
   }
 }

--- a/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/SettingsViewModel.kt
@@ -260,4 +260,8 @@ class SettingsViewModel(
   override fun openDeveloperMenu() {
     navigator.goTo(Destination.DeveloperSettings)
   }
+
+  override fun openMediaNotificationSettings() {
+    navigator.goTo(Destination.MediaNotificationSettings)
+  }
 }

--- a/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsScreen.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsScreen.kt
@@ -1,0 +1,189 @@
+package voice.features.settings.medianotification
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.retain.retain
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import voice.core.common.rootGraphAs
+import voice.core.data.notification.NotificationAction
+import voice.core.ui.icons.VoiceIcons
+import voice.navigation.Destination
+import voice.navigation.NavEntryProvider
+import voice.core.strings.R as StringsR
+
+@Composable
+private fun MediaNotificationSettings(
+  viewState: MediaNotificationSettingsViewState,
+  viewModel: MediaNotificationSettingsViewModel,
+) {
+  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+  Scaffold(
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    topBar = {
+      TopAppBar(
+        scrollBehavior = scrollBehavior,
+        title = {
+          Text(stringResource(StringsR.string.settings_media_notification_title))
+        },
+        navigationIcon = {
+          IconButton(onClick = viewModel::close) {
+            Icon(
+              imageVector = VoiceIcons.Close,
+              contentDescription = stringResource(StringsR.string.common_action_close),
+            )
+          }
+        },
+      )
+    },
+  ) { contentPadding ->
+    LazyColumn(contentPadding = contentPadding) {
+      item {
+        NotificationActionRow(1, viewState.slot1) { viewModel.editSlot(1) }
+      }
+      item {
+        NotificationActionRow(2, viewState.slot2) { viewModel.editSlot(2) }
+      }
+      item {
+        NotificationActionRow(3, viewState.slot3) { viewModel.editSlot(3) }
+      }
+    }
+  }
+
+  val editingSlot = viewState.editingSlot
+  if (editingSlot != null) {
+    val selected = when (editingSlot) {
+      1 -> viewState.slot1
+      2 -> viewState.slot2
+      else -> viewState.slot3
+    }
+    NotificationActionDialog(
+      slot = editingSlot,
+      selectedAction = selected,
+      onActionSelect = { action -> viewModel.selectAction(editingSlot, action) },
+      onDismiss = viewModel::dismissDialog,
+    )
+  }
+}
+
+@Composable
+private fun NotificationActionRow(
+  slot: Int,
+  action: NotificationAction,
+  onClick: () -> Unit,
+) {
+  ListItem(
+    modifier = Modifier
+      .clickable { onClick() }
+      .fillMaxWidth(),
+    headlineContent = {
+      Text(stringResource(StringsR.string.settings_media_notification_button_label, slot))
+    },
+    supportingContent = {
+      Text(action.label())
+    },
+  )
+}
+
+@Composable
+private fun NotificationActionDialog(
+  slot: Int,
+  selectedAction: NotificationAction,
+  onActionSelect: (NotificationAction) -> Unit,
+  onDismiss: () -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = {
+      Text(stringResource(StringsR.string.settings_media_notification_button_label, slot))
+    },
+    text = {
+      Column {
+        NotificationAction.entries.forEach { action ->
+          Row(
+            modifier = Modifier
+              .fillMaxWidth()
+              .selectable(
+                selected = action == selectedAction,
+                onClick = { onActionSelect(action) },
+                role = Role.RadioButton,
+              )
+              .padding(vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            RadioButton(
+              selected = action == selectedAction,
+              onClick = null,
+            )
+            Spacer(Modifier.width(16.dp))
+            Text(action.label())
+          }
+        }
+      }
+    },
+    confirmButton = {},
+  )
+}
+
+@Composable
+private fun NotificationAction.label(): String = when (this) {
+  NotificationAction.REWIND -> stringResource(StringsR.string.playback_action_rewind)
+  NotificationAction.FAST_FORWARD -> stringResource(StringsR.string.playback_action_fast_forward)
+  NotificationAction.NEXT_CHAPTER -> stringResource(StringsR.string.playback_chapter_next)
+  NotificationAction.PREVIOUS_CHAPTER -> stringResource(StringsR.string.playback_chapter_previous)
+  NotificationAction.SLEEP_TIMER -> stringResource(StringsR.string.sleep_timer_action_open)
+  NotificationAction.SKIP_SILENCE -> stringResource(StringsR.string.playback_option_skip_silence)
+  NotificationAction.BOOKMARK -> stringResource(StringsR.string.bookmark_title)
+}
+
+@ContributesTo(AppScope::class)
+interface MediaNotificationSettingsGraph {
+  val mediaNotificationSettingsViewModel: MediaNotificationSettingsViewModel
+}
+
+@ContributesTo(AppScope::class)
+interface MediaNotificationSettingsProvider {
+
+  @Provides
+  @IntoSet
+  fun mediaNotificationSettingsNavEntryProvider(): NavEntryProvider<*> = NavEntryProvider<Destination.MediaNotificationSettings> { key ->
+    NavEntry(key) {
+      MediaNotificationSettings()
+    }
+  }
+}
+
+@Composable
+fun MediaNotificationSettings() {
+  val viewModel = retain<MediaNotificationSettingsViewModel> {
+    rootGraphAs<MediaNotificationSettingsGraph>().mediaNotificationSettingsViewModel
+  }
+  val viewState = viewModel.viewState()
+  MediaNotificationSettings(viewState, viewModel)
+}

--- a/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewModel.kt
@@ -1,0 +1,67 @@
+package voice.features.settings.medianotification
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.datastore.core.DataStore
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.launch
+import voice.core.common.DispatcherProvider
+import voice.core.common.MainScope
+import voice.core.data.notification.MediaNotificationPreferences
+import voice.core.data.notification.NotificationAction
+import voice.core.data.store.MediaNotificationPreferencesStore
+import voice.navigation.Navigator
+
+@Inject
+class MediaNotificationSettingsViewModel(
+  @MediaNotificationPreferencesStore
+  private val preferencesStore: DataStore<MediaNotificationPreferences>,
+  private val navigator: Navigator,
+  dispatcherProvider: DispatcherProvider,
+) {
+
+  private val mainScope = MainScope(dispatcherProvider)
+  private val editingSlot = mutableStateOf<Int?>(null)
+
+  @Composable
+  fun viewState(): MediaNotificationSettingsViewState {
+    val preferences by remember { preferencesStore.data }.collectAsState(initial = MediaNotificationPreferences.Default)
+    return MediaNotificationSettingsViewState(
+      slot1 = preferences.slot1,
+      slot2 = preferences.slot2,
+      slot3 = preferences.slot3,
+      editingSlot = editingSlot.value,
+    )
+  }
+
+  fun close() {
+    navigator.goBack()
+  }
+
+  fun editSlot(slot: Int) {
+    editingSlot.value = slot
+  }
+
+  fun dismissDialog() {
+    editingSlot.value = null
+  }
+
+  fun selectAction(
+    slot: Int,
+    action: NotificationAction,
+  ) {
+    mainScope.launch {
+      preferencesStore.updateData { preferences ->
+        when (slot) {
+          1 -> preferences.copy(slot1 = action)
+          2 -> preferences.copy(slot2 = action)
+          else -> preferences.copy(slot3 = action)
+        }
+      }
+    }
+    editingSlot.value = null
+  }
+}

--- a/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewState.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewState.kt
@@ -1,0 +1,10 @@
+package voice.features.settings.medianotification
+
+import voice.core.data.notification.NotificationAction
+
+data class MediaNotificationSettingsViewState(
+  val slot1: NotificationAction,
+  val slot2: NotificationAction,
+  val slot3: NotificationAction,
+  val editingSlot: Int?,
+)

--- a/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
+++ b/features/settings/src/main/kotlin/voice/features/settings/views/Settings.kt
@@ -160,6 +160,18 @@ private fun Settings(
       }
 
       item {
+        ListItem(
+          modifier = Modifier.clickable { listener.openMediaNotificationSettings() },
+          headlineContent = {
+            Text(stringResource(StringsR.string.settings_media_notification_title))
+          },
+          supportingContent = {
+            Text(stringResource(StringsR.string.settings_media_notification_summary))
+          },
+        )
+      }
+
+      item {
         AutoSleepTimerCard(viewState.autoSleepTimer, listener)
       }
 

--- a/features/settings/src/test/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/voice/features/settings/medianotification/MediaNotificationSettingsViewModelTest.kt
@@ -1,0 +1,103 @@
+package voice.features.settings.medianotification
+
+import androidx.datastore.core.DataStore
+import app.cash.molecule.RecompositionMode
+import app.cash.molecule.launchMolecule
+import app.cash.turbine.test
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import voice.core.common.DispatcherProvider
+import voice.core.data.notification.MediaNotificationPreferences
+import voice.core.data.notification.NotificationAction
+import voice.navigation.Navigator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MediaNotificationSettingsViewModelTest {
+
+  private val scope = TestScope()
+  private val preferencesStore = MemoryDataStore(MediaNotificationPreferences.Default)
+  private val navigator = mockk<Navigator> {
+    every { goBack() } just Runs
+  }
+
+  private val viewModel = MediaNotificationSettingsViewModel(
+    preferencesStore = preferencesStore,
+    navigator = navigator,
+    dispatcherProvider = DispatcherProvider(scope.coroutineContext, scope.coroutineContext, scope.coroutineContext),
+  )
+
+  @Test
+  fun `view state defaults to the stored preferences with no dialog open`() = scope.runTest {
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) {
+      viewModel.viewState()
+    }.test {
+      awaitItem().let {
+        assertEquals(expected = NotificationAction.REWIND, actual = it.slot1)
+        assertEquals(expected = NotificationAction.FAST_FORWARD, actual = it.slot2)
+        assertEquals(expected = NotificationAction.SLEEP_TIMER, actual = it.slot3)
+        assertNull(it.editingSlot)
+      }
+    }
+  }
+
+  @Test
+  fun `editing a slot opens and closes the dialog`() = scope.runTest {
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) {
+      viewModel.viewState()
+    }.test {
+      assertNull(awaitItem().editingSlot)
+
+      viewModel.editSlot(2)
+      assertEquals(expected = 2, actual = awaitItem().editingSlot)
+
+      viewModel.dismissDialog()
+      assertNull(awaitItem().editingSlot)
+    }
+  }
+
+  @Test
+  fun `selecting an action persists it to the matching slot and closes the dialog`() = scope.runTest {
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) {
+      viewModel.viewState()
+    }.test {
+      awaitItem()
+
+      viewModel.editSlot(3)
+      assertEquals(expected = 3, actual = awaitItem().editingSlot)
+
+      viewModel.selectAction(3, NotificationAction.BOOKMARK)
+      awaitItem().let {
+        assertEquals(expected = NotificationAction.BOOKMARK, actual = it.slot3)
+        assertNull(it.editingSlot)
+      }
+    }
+  }
+
+  @Test
+  fun `close navigates back`() {
+    viewModel.close()
+
+    verify { navigator.goBack() }
+  }
+
+  private class MemoryDataStore<T>(initial: T) : DataStore<T> {
+
+    private val value = MutableStateFlow(initial)
+
+    override val data: Flow<T> get() = value
+
+    override suspend fun updateData(transform: suspend (t: T) -> T): T {
+      return value.updateAndGet { transform(it) }
+    }
+  }
+}

--- a/navigation/src/main/kotlin/voice/navigation/Destination.kt
+++ b/navigation/src/main/kotlin/voice/navigation/Destination.kt
@@ -61,6 +61,11 @@ sealed interface Destination {
   }
 
   @Serializable
+  data object MediaNotificationSettings : Compose {
+    override val trackingName: String get() = "MediaNotificationSettings"
+  }
+
+  @Serializable
   data object BookOverview : Compose {
     override val trackingName: String get() = "BookOverview"
   }


### PR DESCRIPTION
Thanks for the nice project, it's a cute app that does what I need.

The sleeping timer and other commands are only accessible from the main screen, this PR introduces an additional button to the media player notification and makes the three buttons configurable. This allows me to turn on/off the sleeping timer or insert a bookmark directly from the media player (notification and lockscreen).

The following screenshot shows the additional button on the bottom-right of the notification. All clickable buttons in this notification except "this phone" and "play/pause" are now provided by the app instead of the framework.

<img width="505" height="270" alt="Media player screenshot" src="https://github.com/user-attachments/assets/df3fc381-12e3-4449-a2b0-321471f30578" />

This is my first android app contribution and while I am a developer I delegate the implementation to Claude and spent time doing user-acceptance in the emulator. I am now daily-driving this and will report/update the PR.

During my back and forth with Claude we also added two items to AGENTS.md . The first documents the practice of using the ViewModel to test screens. The second is about relying on the compiler to check exhaustiveness of code instead of checking each value of an enum. While the first may be useful the second is just nice to have.