### PR TITLE
Fix long mp4 books being silently dropped during import

### DIFF
--- a/core/scanner/src/main/kotlin/voice/core/scanner/MediaAnalyzer.kt
+++ b/core/scanner/src/main/kotlin/voice/core/scanner/MediaAnalyzer.kt
@@ -12,6 +12,7 @@ import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.metadata.id3.ChapterFrame
 import androidx.media3.extractor.metadata.id3.TextInformationFrame
 import androidx.media3.extractor.metadata.vorbis.VorbisComment
+import androidx.media3.extractor.mp4.Mp4Extractor
 import androidx.media3.inspector.MetadataRetriever
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CancellationException
@@ -39,7 +40,8 @@ internal class MediaAnalyzer(
   // retriever also extracts the covers
   private val mediaSourceFactory = DefaultMediaSourceFactory(
     context,
-    DefaultExtractorsFactory(),
+    DefaultExtractorsFactory()
+      .setMp4ExtractorFlags(Mp4Extractor.FLAG_OMIT_TRACK_SAMPLE_TABLE),
   )
 
   suspend fun analyze(file: CachedDocumentFile): Metadata? {


### PR DESCRIPTION
as described in eg https://github.com/PaulWoitaschek/Voice/issues/3672 importing large m4b files does not work.

since we only need the metadata at this point in time, we dont need the sample table, thus we can just set the FLAG_OMIT_TRACK_SAMPLE_TABLE flag.

Note, that this PR just allows the loading of the files into the library. playback still does not work, but I want to do another pr (https://github.com/PaulWoitaschek/Voice/pull/3705) for that.