### PR TITLE
play large mp4 files via the platform MediaExtractor

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -9,6 +9,7 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaLibraryService
@@ -20,6 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import voice.core.featureflag.FeatureFlag
 import voice.core.featureflag.Media3AudioOffloadFeatureFlagQualifier
+import voice.core.playback.mediasource.Mp4AwareMediaSourceFactory
+import voice.core.playback.mediasource.PlatformMediaExtractor
 import voice.core.playback.misc.VolumeGain
 import voice.core.playback.notification.MainActivityIntentProvider
 import voice.core.playback.player.DurationInconsistenciesUpdater
@@ -41,7 +44,10 @@ interface PlaybackModule {
     val dataSourceFactory = DefaultDataSource.Factory(context)
     val extractorsFactory = DefaultExtractorsFactory()
       .setConstantBitrateSeekingEnabled(true)
-    return DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
+    return Mp4AwareMediaSourceFactory(
+      default = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory),
+      mp4 = ProgressiveMediaSource.Factory(dataSourceFactory, PlatformMediaExtractor.Factory(context)),
+    )
   }
 
   @Provides

--- a/core/playback/src/main/kotlin/voice/core/playback/mediasource/Mp4AwareMediaSourceFactory.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/mediasource/Mp4AwareMediaSourceFactory.kt
@@ -1,0 +1,67 @@
+package voice.core.playback.mediasource
+
+import androidx.media3.common.C
+import androidx.media3.common.FileTypes
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.ClippingMediaSource
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+
+/**
+ * Routes mp4 containers to [PlatformMediaExtractor] and everything else to media3's own extractors.
+ */
+internal class Mp4AwareMediaSourceFactory(
+  private val default: MediaSource.Factory,
+  private val mp4: MediaSource.Factory,
+) : MediaSource.Factory {
+
+  override fun createMediaSource(mediaItem: MediaItem): MediaSource {
+    return if (isMp4(mediaItem)) {
+      maybeClip(mediaItem, mp4.createMediaSource(mediaItem))
+    } else {
+      default.createMediaSource(mediaItem)
+    }
+  }
+
+  // Matches .mp4, .m4a, .m4b and .m4v.
+  private fun isMp4(mediaItem: MediaItem): Boolean {
+    val uri = mediaItem.localConfiguration?.uri ?: return false
+    return FileTypes.inferFileTypeFromUri(uri) == FileTypes.MP4
+  }
+
+  private fun maybeClip(
+    mediaItem: MediaItem,
+    source: MediaSource,
+  ): MediaSource {
+    val clipping = mediaItem.clippingConfiguration
+    if (clipping.startPositionUs == 0L &&
+      clipping.endPositionUs == C.TIME_END_OF_SOURCE &&
+      !clipping.relativeToDefaultPosition
+    ) {
+      return source
+    }
+    return ClippingMediaSource.Builder(source)
+      .setStartPositionUs(clipping.startPositionUs)
+      .setEndPositionUs(clipping.endPositionUs)
+      .setEnableInitialDiscontinuity(!clipping.startsAtKeyFrame)
+      .setAllowDynamicClippingUpdates(clipping.relativeToLiveWindow)
+      .setRelativeToDefaultPosition(clipping.relativeToDefaultPosition)
+      .setAllowUnseekableMedia(clipping.allowUnseekableMedia)
+      .build()
+  }
+
+  override fun getSupportedTypes(): IntArray = default.supportedTypes
+
+  override fun setDrmSessionManagerProvider(drmSessionManagerProvider: DrmSessionManagerProvider): MediaSource.Factory {
+    default.setDrmSessionManagerProvider(drmSessionManagerProvider)
+    mp4.setDrmSessionManagerProvider(drmSessionManagerProvider)
+    return this
+  }
+
+  override fun setLoadErrorHandlingPolicy(loadErrorHandlingPolicy: LoadErrorHandlingPolicy): MediaSource.Factory {
+    default.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+    mp4.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+    return this
+  }
+}

--- a/core/playback/src/main/kotlin/voice/core/playback/mediasource/PlatformMediaExtractor.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/mediasource/PlatformMediaExtractor.kt
@@ -1,0 +1,158 @@
+package voice.core.playback.mediasource
+
+import android.content.Context
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.common.DataReader
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.MediaFormatUtil
+import androidx.media3.common.util.ParsableByteArray
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.source.ProgressiveMediaExtractor
+import androidx.media3.extractor.Extractor
+import androidx.media3.extractor.ExtractorOutput
+import androidx.media3.extractor.PositionHolder
+import androidx.media3.extractor.SeekMap
+import androidx.media3.extractor.SeekPoint
+import androidx.media3.extractor.TrackOutput
+import voice.core.logging.api.Logger
+import java.nio.ByteBuffer
+
+/**
+ * A [ProgressiveMediaExtractor] backed by the platform's [MediaExtractor] rather than by media3's
+ * own Mp4Extractor.
+ */
+internal class PlatformMediaExtractor(private val context: Context) : ProgressiveMediaExtractor {
+
+  private var extractor: MediaExtractor? = null
+  private var trackOutputs: Array<TrackOutput?> = arrayOf()
+
+  private var bytesRead = 0L
+
+  private var sampleBytes = ByteArray(0)
+  private var sampleBuffer: ByteBuffer = ByteBuffer.wrap(sampleBytes)
+  private var parsableBuffer = ParsableByteArray(sampleBytes)
+
+  override fun init(
+    dataReader: DataReader,
+    uri: Uri,
+    responseHeaders: Map<String, List<String>>,
+    position: Long,
+    length: Long,
+    output: ExtractorOutput,
+  ) {
+    bytesRead = position
+
+    if (extractor != null) return
+
+    val mediaExtractor = MediaExtractor()
+    try {
+      mediaExtractor.setDataSource(context, uri, null)
+    } catch (e: Throwable) {
+      mediaExtractor.release()
+      throw e
+    }
+    extractor = mediaExtractor
+
+    trackOutputs = arrayOfNulls(mediaExtractor.trackCount)
+    var durationUs = C.TIME_UNSET
+    var maxInputSize = 0
+    repeat(mediaExtractor.trackCount) { index ->
+      val mediaFormat = mediaExtractor.getTrackFormat(index)
+      if (mediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
+        durationUs = maxOf(durationUs, mediaFormat.getLong(MediaFormat.KEY_DURATION))
+      }
+      if (mediaFormat.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+        maxInputSize = maxOf(maxInputSize, mediaFormat.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE))
+      }
+      val format = MediaFormatUtil.createFormatFromMediaFormat(mediaFormat)
+      if (MimeTypes.getTrackType(format.sampleMimeType) == C.TRACK_TYPE_AUDIO) {
+        val trackOutput = output.track(index, C.TRACK_TYPE_AUDIO)
+        trackOutput.format(
+          format.buildUpon()
+            .setEncoderDelay(mediaFormat.intOrZero(KEY_ENCODER_DELAY))
+            .setEncoderPadding(mediaFormat.intOrZero(KEY_ENCODER_PADDING))
+            .build(),
+        )
+        trackOutputs[index] = trackOutput
+        mediaExtractor.selectTrack(index)
+      }
+    }
+    sampleBytes = ByteArray(if (maxInputSize > 0) maxInputSize else FALLBACK_BUFFER_SIZE)
+    sampleBuffer = ByteBuffer.wrap(sampleBytes)
+    parsableBuffer = ParsableByteArray(sampleBytes)
+
+    output.endTracks()
+    output.seekMap(TimeBasedSeekMap(durationUs))
+    Logger.d("PlatformMediaExtractor prepared $uri, durationUs=$durationUs")
+  }
+
+  override fun read(positionHolder: PositionHolder): Int {
+    val mediaExtractor = extractor ?: return Extractor.RESULT_END_OF_INPUT
+    val trackIndex = mediaExtractor.sampleTrackIndex
+    if (trackIndex < 0) return Extractor.RESULT_END_OF_INPUT
+
+    val size = mediaExtractor.readSampleData(sampleBuffer, 0)
+    if (size < 0) return Extractor.RESULT_END_OF_INPUT
+    bytesRead += size
+
+    val trackOutput = trackOutputs.getOrNull(trackIndex)
+    if (trackOutput != null) {
+      val timeUs = mediaExtractor.sampleTime
+      parsableBuffer.reset(sampleBytes, size)
+      trackOutput.sampleData(parsableBuffer, size)
+      val flags = if (mediaExtractor.sampleFlags and MediaExtractor.SAMPLE_FLAG_SYNC != 0) {
+        C.BUFFER_FLAG_KEY_FRAME
+      } else {
+        0
+      }
+      trackOutput.sampleMetadata(timeUs, flags, size, 0, null)
+    }
+    return if (mediaExtractor.advance()) Extractor.RESULT_CONTINUE else Extractor.RESULT_END_OF_INPUT
+  }
+
+  override fun seek(
+    position: Long,
+    timeUs: Long,
+  ) {
+    extractor?.seekTo(timeUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+  }
+
+  override fun getCurrentInputPosition(): Long = bytesRead
+
+  override fun disableSeekingOnMp3Streams() = Unit
+
+  override fun release() {
+    extractor?.release()
+    extractor = null
+    trackOutputs = arrayOf()
+    bytesRead = 0
+  }
+
+  private class TimeBasedSeekMap(private val durationUs: Long) : SeekMap {
+    override fun isSeekable(): Boolean = true
+
+    override fun getDurationUs(): Long = durationUs
+
+    override fun getSeekPoints(timeUs: Long): SeekMap.SeekPoints {
+      return SeekMap.SeekPoints(SeekPoint(timeUs, 0))
+    }
+  }
+
+  class Factory(private val context: Context) : ProgressiveMediaExtractor.Factory {
+    override fun createProgressiveMediaExtractor(playerId: PlayerId): ProgressiveMediaExtractor {
+      return PlatformMediaExtractor(context)
+    }
+  }
+
+  private companion object {
+    const val FALLBACK_BUFFER_SIZE = 64 * 1024
+
+    const val KEY_ENCODER_DELAY = "encoder-delay"
+    const val KEY_ENCODER_PADDING = "encoder-padding"
+
+    fun MediaFormat.intOrZero(key: String): Int = if (containsKey(key)) getInteger(key) else 0
+  }
+}

--- a/core/playback/src/test/kotlin/voice/core/playback/mediasource/Mp4AwareMediaSourceFactoryTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/mediasource/Mp4AwareMediaSourceFactoryTest.kt
@@ -1,0 +1,125 @@
+package voice.core.playback.mediasource
+
+import android.net.Uri
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.ClippingMediaSource
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import androidx.media3.test.utils.FakeMediaSource
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+@RunWith(AndroidJUnit4::class)
+class Mp4AwareMediaSourceFactoryTest {
+
+  private val default = RecordingFactory()
+  private val mp4 = RecordingFactory()
+  private val factory = Mp4AwareMediaSourceFactory(default = default, mp4 = mp4)
+
+  @Test
+  fun `routes mp4 containers to the platform extractor`() {
+    val uris = listOf(
+      "file:///books/book.mp4",
+      "file:///books/book.m4a",
+      "file:///books/book.m4b",
+      "content://com.android.externalstorage.documents/document/primary%3ABooks%2Fbook.m4b",
+    )
+    uris.forEach { factory.createMediaSource(mediaItem(it)) }
+
+    assertEquals(expected = uris.map(Uri::parse), actual = mp4.mediaItems.map { it.uri() })
+    assertEquals(expected = emptyList(), actual = default.mediaItems)
+  }
+
+  @Test
+  fun `routes everything else to the default factory`() {
+    val uris = listOf(
+      "file:///books/book.mp3",
+      "file:///books/book.ogg",
+      "file:///books/book.opus",
+      "file:///books/book.mka",
+      "file:///books/book",
+    )
+    uris.forEach { factory.createMediaSource(mediaItem(it)) }
+
+    assertEquals(expected = uris.map(Uri::parse), actual = default.mediaItems.map { it.uri() })
+    assertEquals(expected = emptyList(), actual = mp4.mediaItems)
+  }
+
+  @Test
+  fun `clips mp4 sources itself`() {
+    val source = factory.createMediaSource(
+      mediaItem("file:///books/book.m4b", startMs = 2_000, endMs = 6_000),
+    )
+
+    // ProgressiveMediaSource.Factory ignores the clipping configuration, so the chapter mark would
+    // otherwise play from the start of the file and never end.
+    assertIs<ClippingMediaSource>(source)
+    assertEquals(expected = 4_000, actual = source.preparedDurationMs())
+  }
+
+  @Test
+  fun `leaves unclipped mp4 sources alone`() {
+    val source = factory.createMediaSource(mediaItem("file:///books/book.m4b"))
+
+    assertSame(expected = mp4.created.single(), actual = source)
+  }
+
+  @Test
+  fun `leaves clipping of other containers to the default factory`() {
+    val source = factory.createMediaSource(
+      mediaItem("file:///books/book.mp3", startMs = 5_000, endMs = 12_000),
+    )
+
+    assertSame(expected = default.created.single(), actual = source)
+  }
+
+  private fun mediaItem(
+    uri: String,
+    startMs: Long = 0,
+    endMs: Long = C.TIME_END_OF_SOURCE,
+  ): MediaItem = MediaItem.Builder()
+    .setUri(uri)
+    .setClippingConfiguration(
+      MediaItem.ClippingConfiguration.Builder()
+        .setStartPositionMs(startMs)
+        .setEndPositionMs(endMs)
+        .build(),
+    )
+    .build()
+
+  private fun MediaItem.uri(): Uri? = localConfiguration?.uri
+
+  private fun MediaSource.preparedDurationMs(): Long {
+    var timeline: Timeline? = null
+    prepareSource({ _, refreshed -> timeline = refreshed }, null, PlayerId.UNSET)
+    shadowOf(Looper.getMainLooper()).idle()
+    return timeline!!.getWindow(0, Timeline.Window()).durationMs
+  }
+
+  private class RecordingFactory : MediaSource.Factory {
+
+    val mediaItems = mutableListOf<MediaItem>()
+    val created = mutableListOf<MediaSource>()
+
+    override fun createMediaSource(mediaItem: MediaItem): MediaSource {
+      mediaItems += mediaItem
+      return FakeMediaSource().also { created += it }
+    }
+
+    override fun getSupportedTypes(): IntArray = intArrayOf(C.CONTENT_TYPE_OTHER)
+
+    override fun setDrmSessionManagerProvider(drmSessionManagerProvider: DrmSessionManagerProvider): MediaSource.Factory = this
+
+    override fun setLoadErrorHandlingPolicy(loadErrorHandlingPolicy: LoadErrorHandlingPolicy): MediaSource.Factory = this
+  }
+}


### PR DESCRIPTION
this is a follow up pr for https://github.com/PaulWoitaschek/Voice/pull/3704
it actually fixes the playback of large m4b files.

after I fixed the import of huge m4b files locally, I noticed that when they are played I get an OOM, because of the heapgrowthlimit. 
the actual issue is I think in the media3 implementation, not sure why they need almost 300mb heap for a 3gb audiobook file.

I tried using android.media.MediaParser but I get the same issue there. android.media.MediaExtractor however works, but needs a bit of extra work, thats what the PlatformMediaExtractor class is for. The Mp4AwareMediaSourceFactory is just there for routing the mp4 containers (those are the ones I had so far trouble with), the other filetypes are left untouched.

Note: 
- getCurrentInputPosition() is a bit hacky, we have no access to the MediaExtractor internals, so we just do the running sum of sample sizes here.
- Mp4AwareMediaSourceFactory needs to reapply the clipping config, otherwise chapters are not working properly.

tested it locally on my device with the problematic file.


used the following to generate a test m4b file:

```bash
#!/usr/bin/env bash
# Generate a long m4b for testing media3's per-sample sample-table allocation.
#
# The heap cost in Mp4Extractor is driven by the *sample count*, not by the file size:
# 32 bytes per audio frame (offsets 8 + timestamps 8 + sizes 4 + flags 4, plus 8 for
# accumulatedSampleSizes). AAC-LC at 44.1 kHz produces 43.07 frames/s = 155,040 frames per
# hour, so an hour costs 4.96 MB of java heap regardless of bitrate. Encoding silence at a
# low bitrate therefore gives a file that is byte-for-byte small but has exactly the sample
# table that triggers the OOM.
#
#   8.39M samples / 54.1 h  is where the arrays alone reach the 256 MB heapgrowthlimit
#   8.53M samples / 55 h    ~ Chrysalis Books 1-3, the file this was found on (8,479,389)
#   60 h and up             leaves headroom for the rest of the app, a safer reproducer
#
# Usage: ./make-test-m4b.sh [hours] [chapters] [output]
#        ./make-test-m4b.sh 55 433 test-55h.m4b
#
# Env:
#   FASTSTART=0   leave mdat before moov (default 1, moov first like the real file)
#   SOURCE=noise  encode noise instead of silence (silence compresses to ~1.3 kbps)
#   CODEC=alac    lossless, ~88 KiB/s on noise, for growing mdat quickly
#   BITRATE=96k   aac only
#
# To reproduce the >2 GB mdat integer overflow in Mp4BoxParser.parseBoxes instead, the mdat
# has to be both huge and *before* moov:
#
#   SOURCE=noise CODEC=alac FASTSTART=0 ./make-test-m4b.sh 7 20 test-2gb-mdat.m4b
set -euo pipefail

HOURS=${1:-55}
CHAPTERS=${2:-433}
OUT=${3:-test-${HOURS}h.m4b}
BITRATE=${BITRATE:-8k}
SOURCE=${SOURCE:-silence}
CODEC=${CODEC:-aac}
FASTSTART=${FASTSTART:-1}

SECONDS_TOTAL=$(python3 -c "print(int($HOURS * 3600))")
WORK=$(mktemp -d)
trap 'rm -rf "$WORK"' EXIT

case "$SOURCE" in
  silence) INPUT="anullsrc=r=44100:cl=mono" ;;
  noise) INPUT="anoisesrc=r=44100:c=pink:a=0.5" ;;
  *)
    echo "SOURCE must be 'silence' or 'noise'" >&2
    exit 1
    ;;
esac

python3 - "$SECONDS_TOTAL" "$CHAPTERS" > "$WORK/chapters.txt" <<'PY'
import sys
total_ms = int(sys.argv[1]) * 1000
count = int(sys.argv[2])
print(";FFMETADATA1")
print("title=Test Book")
print("artist=Test Author")
print("album=Test Book")
for i in range(count):
    start = total_ms * i // count
    end = total_ms * (i + 1) // count
    print("[CHAPTER]")
    print("TIMEBASE=1/1000")
    print(f"START={start}")
    print(f"END={end}")
    print(f"title=Chapter {i + 1}")
PY

MOVFLAGS=(-movflags "+faststart")
[ "$FASTSTART" = "1" ] || MOVFLAGS=()

CODEC_ARGS=(-c:a "$CODEC")
[ "$CODEC" = "aac" ] && CODEC_ARGS+=(-b:a "$BITRATE")

echo "encoding ${HOURS}h / ${CHAPTERS} chapters as ${CODEC} (${SOURCE}) -> $OUT"
ffmpeg -hide_banner -loglevel warning -stats \
  -f lavfi -i "$INPUT" \
  -f ffmetadata -i "$WORK/chapters.txt" \
  -map 0:a -map_metadata 1 \
  -t "$SECONDS_TOTAL" \
  "${CODEC_ARGS[@]}" \
  "${MOVFLAGS[@]}" \
  -f ipod -brand "M4B " \
  -y "$OUT"

ls -lh "$OUT"
```