### PR TITLE
Stop the shake detector when a shake is detected

### DIFF
--- a/core/sleeptimer/impl/src/main/kotlin/voice/core/sleeptimer/ShakeDetectorImpl.kt
+++ b/core/sleeptimer/impl/src/main/kotlin/voice/core/sleeptimer/ShakeDetectorImpl.kt
@@ -5,27 +5,23 @@ import android.hardware.SensorManager
 import androidx.core.content.getSystemService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
 import com.squareup.seismic.ShakeDetector as SeismicShakeDetector
 
 @ContributesBinding(AppScope::class)
 class ShakeDetectorImpl(private val context: Context) : ShakeDetector {
 
   override suspend fun detect() {
-    suspendCancellableCoroutine { cont ->
-      val sensorManager = context.getSystemService<SensorManager>()
-        ?: return@suspendCancellableCoroutine
-      val listener = SeismicShakeDetector.Listener {
-        if (!cont.isCompleted) {
-          cont.resume(Unit)
-        }
-      }
-      val shakeDetector = SeismicShakeDetector(listener)
-      shakeDetector.start(sensorManager, SensorManager.SENSOR_DELAY_GAME)
-      cont.invokeOnCancellation {
-        shakeDetector.stop()
-      }
+    val sensorManager = context.getSystemService<SensorManager>() ?: awaitCancellation()
+    val shaken = CompletableDeferred<Unit>()
+    val listener = SeismicShakeDetector.Listener { shaken.complete(Unit) }
+    val shakeDetector = SeismicShakeDetector(listener)
+    shakeDetector.start(sensorManager, SensorManager.SENSOR_DELAY_GAME)
+    try {
+      shaken.await()
+    } finally {
+      shakeDetector.stop()
     }
   }
 }


### PR DESCRIPTION
`ShakeDetectorImpl.detect()` only stopped the shake detector from
`cont.invokeOnCancellation { }`. 

On a successful shake the listener calls `cont.resume(Unit)`, so the coroutine
completes normally, `invokeOnCancellation` never fires, and the
`SensorEventListener` registered at `SENSOR_DELAY_GAME` stays registered for the
rest of the process lifetime -- including during ordinary playback with no sleep
timer running. 