### PR TITLE
Fix trailing silence in VBR MP3 playback

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/di/PlaybackModule.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.Player
-import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaLibraryService
 import dev.zacsweers.metro.ContributesTo
@@ -23,9 +25,12 @@ import voice.core.featureflag.Media3AudioOffloadFeatureFlagQualifier
 import voice.core.playback.misc.VolumeGain
 import voice.core.playback.notification.MainActivityIntentProvider
 import voice.core.playback.player.DurationInconsistenciesUpdater
+import voice.core.playback.player.IndexSeekingMp3DataSource
 import voice.core.playback.player.OnlyAudioRenderersFactory
 import voice.core.playback.player.VoicePlayer
+import voice.core.playback.player.audiobookSilenceSkippingAudioProcessor
 import voice.core.playback.player.onAudioSessionIdChanged
+import voice.core.playback.player.setAudioOffloadEnabled
 import voice.core.playback.playstate.PlayStateDelegatingListener
 import voice.core.playback.playstate.PositionUpdater
 import voice.core.playback.session.LibrarySessionCallback
@@ -37,10 +42,20 @@ interface PlaybackModule {
 
   @Provides
   @SingleIn(PlaybackScope::class)
+  fun silenceSkippingAudioProcessor(): SilenceSkippingAudioProcessor {
+    return audiobookSilenceSkippingAudioProcessor()
+  }
+
+  @Provides
+  @SingleIn(PlaybackScope::class)
   fun mediaSourceFactory(context: Context): MediaSource.Factory {
-    val dataSourceFactory = DefaultDataSource.Factory(context)
+    val upstreamDataSourceFactory = DefaultDataSource.Factory(context)
+    val dataSourceFactory = DataSource.Factory {
+      IndexSeekingMp3DataSource(upstreamDataSourceFactory.createDataSource())
+    }
     val extractorsFactory = DefaultExtractorsFactory()
       .setConstantBitrateSeekingEnabled(true)
+      .setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING)
     return DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
   }
 
@@ -68,16 +83,7 @@ interface PlaybackModule {
       .build()
       .also { player ->
         if (media3AudioOffloadFeatureFlag.get()) {
-          player.trackSelectionParameters = player.trackSelectionParameters
-            .buildUpon()
-            .setAudioOffloadPreferences(
-              TrackSelectionParameters.AudioOffloadPreferences.Builder()
-                .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
-                .setIsGaplessSupportRequired(true)
-                .setIsSpeedChangeSupportRequired(true)
-                .build(),
-            )
-            .build()
+          player.setAudioOffloadEnabled(true)
         }
         playStateDelegatingListener.attachTo(player)
         positionUpdater.attachTo(player)

--- a/core/playback/src/main/kotlin/voice/core/playback/player/DurationInconsistenciesUpdater.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/DurationInconsistenciesUpdater.kt
@@ -1,20 +1,24 @@
 package voice.core.playback.player
 
+import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import voice.core.data.repo.ChapterRepo
 import voice.core.logging.api.Logger
 import voice.core.playback.session.MediaId
+import voice.core.playback.session.realChapterId
 import voice.core.playback.session.toMediaIdOrNull
 
 @Inject
-class DurationInconsistenciesUpdater(private val chapterRepo: ChapterRepo) : Player.Listener {
+class DurationInconsistenciesUpdater(
+  private val chapterRepo: ChapterRepo,
+  private val scope: CoroutineScope,
+) : Player.Listener {
 
   private lateinit var player: Player
-
-  private val scope = MainScope()
 
   fun attachTo(player: Player) {
     this.player = player
@@ -22,21 +26,44 @@ class DurationInconsistenciesUpdater(private val chapterRepo: ChapterRepo) : Pla
   }
 
   override fun onPlaybackStateChanged(playbackState: Int) {
-    if (playbackState != Player.STATE_READY) return
+    if (playbackState == Player.STATE_READY) {
+      updateDurationIfNeeded()
+    }
+  }
+
+  override fun onTimelineChanged(
+    timeline: Timeline,
+    reason: Int,
+  ) {
+    updateDurationIfNeeded()
+  }
+
+  private fun updateDurationIfNeeded() {
     val mediaId = player.currentMediaItem?.mediaId?.toMediaIdOrNull()
       ?: return
-    if (mediaId is MediaId.Chapter) {
-      val playerDuration = player.duration
-      scope.launch {
-        val chapter = chapterRepo.get(mediaId.chapterId)
-        if (chapter != null && chapter.duration != playerDuration) {
-          Logger.d(
-            """For chapter=${chapter.id}, we had ${chapter.duration},
-            |but the player reported $playerDuration. Updating the chapter now
-            """.trimMargin(),
-          )
-          chapterRepo.put(chapter.copy(duration = playerDuration))
-        }
+    val playerDuration = player.duration
+    if (playerDuration == C.TIME_UNSET || playerDuration <= 0) return
+
+    val chapterDuration = when (mediaId) {
+      is MediaId.Chapter -> playerDuration
+      is MediaId.ChapterMark -> {
+        val endPositionMs = player.currentMediaItem?.clippingConfiguration?.endPositionMs
+        if (endPositionMs != C.TIME_END_OF_SOURCE) return
+        mediaId.startMs + playerDuration
+      }
+      else -> return
+    }
+    val chapterId = mediaId.realChapterId ?: return
+
+    scope.launch {
+      val chapter = chapterRepo.get(chapterId)
+      if (chapter != null && chapter.duration != chapterDuration) {
+        Logger.d(
+          """For chapter=${chapter.id}, we had ${chapter.duration},
+          |but the player reported $chapterDuration. Updating the chapter now
+          """.trimMargin(),
+        )
+        chapterRepo.put(chapter.copy(duration = chapterDuration))
       }
     }
   }

--- a/core/playback/src/main/kotlin/voice/core/playback/player/ExoPlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/ExoPlayer.kt
@@ -2,7 +2,27 @@ package voice.core.playback.player
 
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.ExoPlayer
+
+internal fun ExoPlayer.setAudioOffloadEnabled(enabled: Boolean) {
+  trackSelectionParameters = trackSelectionParameters
+    .buildUpon()
+    .setAudioOffloadPreferences(
+      TrackSelectionParameters.AudioOffloadPreferences.Builder()
+        .setAudioOffloadMode(
+          if (enabled) {
+            TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED
+          } else {
+            TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_DISABLED
+          },
+        )
+        .setIsGaplessSupportRequired(true)
+        .setIsSpeedChangeSupportRequired(true)
+        .build(),
+    )
+    .build()
+}
 
 internal fun Player.onAudioSessionIdChanged(action: (audioSessionId: Int?) -> Unit) {
   fun emitSessionId(id: Int) {

--- a/core/playback/src/main/kotlin/voice/core/playback/player/IndexSeekingMp3DataSource.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/IndexSeekingMp3DataSource.kt
@@ -1,0 +1,24 @@
+package voice.core.playback.player
+
+import androidx.media3.common.C
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+
+/**
+ * Makes headerless VBR MP3 files eligible for Media3's index seeker.
+ *
+ * Media3 otherwise assumes that a seekable, known-length MP3 without a Xing/VBRI table is CBR.
+ * That produces a wrong duration when the file is actually VBR. The index seeker is selected when
+ * the byte length is unknown and builds an exact time-to-byte map while reading the file.
+ */
+internal class IndexSeekingMp3DataSource(private val upstream: DataSource) : DataSource by upstream {
+
+  override fun open(dataSpec: DataSpec): Long {
+    val resolvedLength = upstream.open(dataSpec)
+    return if (dataSpec.uri.lastPathSegment?.endsWith(".mp3", ignoreCase = true) == true) {
+      C.LENGTH_UNSET.toLong()
+    } else {
+      resolvedLength
+    }
+  }
+}

--- a/core/playback/src/main/kotlin/voice/core/playback/player/OnlyAudioRenderersFactory.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/OnlyAudioRenderersFactory.kt
@@ -3,8 +3,12 @@ package voice.core.playback.player
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import androidx.media3.common.audio.SonicAudioProcessor
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.metadata.MetadataOutput
 import androidx.media3.exoplayer.text.TextOutput
@@ -12,7 +16,27 @@ import androidx.media3.exoplayer.video.VideoRendererEventListener
 import dev.zacsweers.metro.Inject
 
 @Inject
-class OnlyAudioRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+class OnlyAudioRenderersFactory(
+  context: Context,
+  private val silenceSkippingAudioProcessor: SilenceSkippingAudioProcessor,
+) : DefaultRenderersFactory(context) {
+
+  override fun buildAudioSink(
+    context: Context,
+    enableFloatOutput: Boolean,
+    enableAudioOutputPlaybackParams: Boolean,
+  ): AudioSink {
+    val audioProcessorChain = DefaultAudioSink.DefaultAudioProcessorChain(
+      emptyArray(),
+      silenceSkippingAudioProcessor,
+      SonicAudioProcessor(),
+    )
+    return DefaultAudioSink.Builder(context)
+      .setEnableFloatOutput(enableFloatOutput)
+      .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
+      .setAudioProcessorChain(audioProcessorChain)
+      .build()
+  }
 
   override fun buildVideoRenderers(
     context: Context,
@@ -59,3 +83,19 @@ class OnlyAudioRenderersFactory(context: Context) : DefaultRenderersFactory(cont
   ) {
   }
 }
+
+internal fun audiobookSilenceSkippingAudioProcessor(): SilenceSkippingAudioProcessor {
+  return SilenceSkippingAudioProcessor(
+    MINIMUM_SILENCE_DURATION_US,
+    SILENCE_RETENTION_RATIO,
+    MAX_SILENCE_TO_KEEP_DURATION_US,
+    MIN_VOLUME_TO_KEEP_PERCENTAGE_WHEN_MUTING,
+    SILENCE_THRESHOLD_LEVEL,
+  )
+}
+
+internal const val MINIMUM_SILENCE_DURATION_US = 1_000_000L
+internal const val SILENCE_RETENTION_RATIO = 0.1f
+internal const val MAX_SILENCE_TO_KEEP_DURATION_US = 500_000L
+internal const val MIN_VOLUME_TO_KEEP_PERCENTAGE_WHEN_MUTING = 10
+internal const val SILENCE_THRESHOLD_LEVEL: Short = 2_048

--- a/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
@@ -18,6 +18,8 @@ import voice.core.data.repo.BookRepository
 import voice.core.data.store.AutoRewindAmountStore
 import voice.core.data.store.CurrentBookStore
 import voice.core.data.store.SeekTimeStore
+import voice.core.featureflag.FeatureFlag
+import voice.core.featureflag.Media3AudioOffloadFeatureFlagQualifier
 import voice.core.logging.api.Logger
 import voice.core.playback.misc.Decibel
 import voice.core.playback.misc.VolumeGain
@@ -49,6 +51,8 @@ class VoicePlayer(
   private val volumeGain: VolumeGain,
   private val sleepTimer: SleepTimer,
   private val analytics: Analytics,
+  @Media3AudioOffloadFeatureFlagQualifier
+  private val media3AudioOffloadFeatureFlag: FeatureFlag<Boolean>,
 ) : ForwardingPlayer(player) {
 
   private val endOfChapterSleepTimerListener = object : Player.Listener {
@@ -333,7 +337,13 @@ class VoicePlayer(
       updateBook { it.copy(skipSilence = enabled) }
     }
     if (player is ExoPlayer) {
+      if (enabled) {
+        player.setAudioOffloadEnabled(false)
+      }
       player.skipSilenceEnabled = enabled
+      if (!enabled && media3AudioOffloadFeatureFlag.get()) {
+        player.setAudioOffloadEnabled(true)
+      }
     }
   }
 

--- a/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/MediaItemProvider.kt
@@ -158,23 +158,31 @@ class MediaItemProvider(
   private fun mediaItem(
     playbackItem: PlaybackItem,
     content: BookContent,
-  ) = MediaItem(
-    title = playbackItem.mark.name
-      ?: playbackItem.chapter.name
-      ?: playbackItem.chapter.id.value,
-    mediaId = playbackItem.mediaId,
-    browsable = false,
-    isPlayable = true,
-    sourceUri = playbackItem.chapter.id.toUri(),
-    imageUri = content.cover?.toProvidedUri(),
-    artist = content.author,
-    durationMs = playbackItem.mark.durationMs,
-    clippingConfiguration = ClippingConfiguration.Builder()
+  ): MediaItem {
+    val clippingConfiguration = ClippingConfiguration.Builder()
       .setStartPositionMs(playbackItem.mark.startMs)
-      .setEndPositionMs(playbackItem.mark.endMs)
-      .build(),
-    mediaType = MediaType.AudioBookChapter,
-  )
+      .apply {
+        if (playbackItem.markIndex != playbackItem.chapter.chapterMarks.lastIndex) {
+          setEndPositionMs(playbackItem.mark.endMs)
+        }
+      }
+      .build()
+
+    return MediaItem(
+      title = playbackItem.mark.name
+        ?: playbackItem.chapter.name
+        ?: playbackItem.chapter.id.value,
+      mediaId = playbackItem.mediaId,
+      browsable = false,
+      isPlayable = true,
+      sourceUri = playbackItem.chapter.id.toUri(),
+      imageUri = content.cover?.toProvidedUri(),
+      artist = content.author,
+      durationMs = playbackItem.mark.durationMs,
+      clippingConfiguration = clippingConfiguration,
+      mediaType = MediaType.AudioBookChapter,
+    )
+  }
 
   private fun File.toProvidedUri(): Uri = imageFileProvider.uri(this)
 }

--- a/core/playback/src/test/kotlin/voice/core/playback/player/DurationInconsistenciesUpdaterTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/DurationInconsistenciesUpdaterTest.kt
@@ -1,0 +1,111 @@
+package voice.core.playback.player
+
+import androidx.media3.common.MediaItem.ClippingConfiguration
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.repo.ChapterRepo
+import voice.core.playback.session.MediaId
+import voice.core.playback.session.MediaType
+import java.time.Instant
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+class DurationInconsistenciesUpdaterTest {
+
+  private val scope = TestScope()
+  private val chapter = Chapter(
+    id = ChapterId("chapter"),
+    name = "Chapter",
+    duration = 696_276,
+    fileLastModified = Instant.EPOCH,
+    markData = emptyList(),
+    fileSize = 0,
+  )
+  private val chapterRepo = mockk<ChapterRepo> {
+    coEvery { get(chapter.id) } returns chapter
+    coEvery { put(any()) } just Runs
+  }
+
+  @Test
+  fun `updates chapter duration from final mark timeline`() = scope.runTest {
+    val markStartMs = 120_000L
+    val playerDurationMs = 498_912L
+    val player = player(
+      startMs = markStartMs,
+      endMs = ClippingConfiguration.UNSET.endPositionMs,
+      durationMs = playerDurationMs,
+    )
+    val updater = DurationInconsistenciesUpdater(chapterRepo, scope)
+    updater.attachTo(player)
+
+    updater.onTimelineChanged(Timeline.EMPTY, Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE)
+    runCurrent()
+
+    coVerify(exactly = 1) {
+      chapterRepo.put(chapter.copy(duration = markStartMs + playerDurationMs))
+    }
+  }
+
+  @Test
+  fun `does not update chapter duration from bounded mark timeline`() = scope.runTest {
+    val player = player(
+      startMs = 120_000,
+      endMs = 200_000,
+      durationMs = 80_000,
+    )
+    val updater = DurationInconsistenciesUpdater(chapterRepo, scope)
+    updater.attachTo(player)
+
+    updater.onTimelineChanged(Timeline.EMPTY, Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE)
+    runCurrent()
+
+    coVerify(exactly = 0) { chapterRepo.put(any()) }
+  }
+
+  private fun player(
+    startMs: Long,
+    endMs: Long,
+    durationMs: Long,
+  ): Player {
+    val clippingConfiguration = ClippingConfiguration.Builder()
+      .setStartPositionMs(startMs)
+      .apply {
+        if (endMs != ClippingConfiguration.UNSET.endPositionMs) {
+          setEndPositionMs(endMs)
+        }
+      }
+      .build()
+    val mediaItem = voice.core.playback.session.MediaItem(
+      title = "Chapter",
+      mediaId = MediaId.ChapterMark(
+        bookId = BookId("book"),
+        chapterId = chapter.id,
+        markIndex = 0,
+        startMs = startMs,
+        endMs = endMs,
+      ),
+      isPlayable = true,
+      browsable = false,
+      clippingConfiguration = clippingConfiguration,
+      mediaType = MediaType.AudioBookChapter,
+    )
+    return mockk(relaxed = true) {
+      every { currentMediaItem } returns mediaItem
+      every { duration } returns durationMs
+    }
+  }
+}

--- a/core/playback/src/test/kotlin/voice/core/playback/player/IndexSeekingMp3DataSourceTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/IndexSeekingMp3DataSourceTest.kt
@@ -1,0 +1,45 @@
+package voice.core.playback.player
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class IndexSeekingMp3DataSourceTest {
+
+  @Test
+  fun `reports unknown length for mp3 so index seeking is used`() {
+    val dataSpec = DataSpec(Uri.parse("content://books/chapter.MP3"))
+    val upstream = upstreamDataSource(dataSpec, length = 1234L)
+
+    val length = IndexSeekingMp3DataSource(upstream).open(dataSpec)
+
+    assertEquals(C.LENGTH_UNSET.toLong(), length)
+  }
+
+  @Test
+  fun `preserves resolved length for other formats`() {
+    val dataSpec = DataSpec(Uri.parse("content://books/chapter.m4b"))
+    val upstream = upstreamDataSource(dataSpec, length = 1234L)
+
+    val length = IndexSeekingMp3DataSource(upstream).open(dataSpec)
+
+    assertEquals(1234L, length)
+  }
+
+  private fun upstreamDataSource(
+    dataSpec: DataSpec,
+    length: Long,
+  ): DataSource {
+    return mockk {
+      every { open(dataSpec) } returns length
+    }
+  }
+}

--- a/core/playback/src/test/kotlin/voice/core/playback/player/OnlyAudioRenderersFactoryTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/OnlyAudioRenderersFactoryTest.kt
@@ -1,0 +1,63 @@
+package voice.core.playback.player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OnlyAudioRenderersFactoryTest {
+
+  @Test
+  fun `long low-volume audio at start and end is shortened`() {
+    val lowVolumeFrames = ShortArray(4_000) { LOW_VOLUME_SAMPLE }
+    val spokenFrames = ShortArray(1_000) { SPOKEN_AUDIO_SAMPLE }
+
+    val leadingLowVolumeOutput = processFrames(lowVolumeFrames + spokenFrames)
+    val trailingLowVolumeOutput = processFrames(spokenFrames + lowVolumeFrames)
+
+    assertEquals(1_500, leadingLowVolumeOutput)
+    assertEquals(1_500, trailingLowVolumeOutput)
+  }
+
+  @Test
+  fun `short low-volume audio is preserved`() {
+    val input = ShortArray(500) { LOW_VOLUME_SAMPLE }
+
+    val outputFrameCount = processFrames(input)
+
+    assertEquals(input.size, outputFrameCount)
+  }
+
+  @Suppress("DEPRECATION")
+  private fun processFrames(samples: ShortArray): Int {
+    val processor = audiobookSilenceSkippingAudioProcessor()
+    processor.setEnabled(true)
+    processor.configure(AudioProcessor.AudioFormat(SAMPLE_RATE, 1, C.ENCODING_PCM_16BIT))
+    processor.flush()
+
+    val input = ByteBuffer.allocateDirect(samples.size * Short.SIZE_BYTES)
+      .order(ByteOrder.nativeOrder())
+    samples.forEach { sample ->
+      input.putShort(sample)
+    }
+    input.flip()
+
+    var outputByteCount = 0
+    while (input.hasRemaining()) {
+      processor.queueInput(input)
+      outputByteCount += processor.output.remaining()
+    }
+    processor.queueEndOfStream()
+    while (!processor.isEnded) {
+      outputByteCount += processor.output.remaining()
+    }
+
+    return outputByteCount / Short.SIZE_BYTES
+  }
+}
+
+private const val SAMPLE_RATE = 1_000
+private const val LOW_VOLUME_SAMPLE: Short = 1_500
+private const val SPOKEN_AUDIO_SAMPLE: Short = 5_000

--- a/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/player/VoicePlayerTest.kt
@@ -2,6 +2,7 @@ package voice.core.playback.player
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.test.utils.FakeMediaSource
 import androidx.media3.test.utils.FakeTimeline
 import androidx.media3.test.utils.TestExoPlayerBuilder
@@ -27,6 +28,7 @@ import voice.core.data.Chapter
 import voice.core.data.ChapterId
 import voice.core.data.ChapterMark
 import voice.core.data.MarkData
+import voice.core.featureflag.MemoryFeatureFlag
 import voice.core.logging.api.LogWriter
 import voice.core.logging.api.Logger
 import voice.core.playback.MemoryDataStore
@@ -42,6 +44,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 @RunWith(AndroidJUnit4::class)
@@ -110,7 +113,27 @@ class VoicePlayerTest {
     volumeGain = mockk(relaxed = true),
     sleepTimer = sleepTimer,
     analytics = mockk(relaxed = true),
+    media3AudioOffloadFeatureFlag = MemoryFeatureFlag(true),
   )
+
+  @Test
+  fun `skip silence disables incompatible audio offload`() = scope.runTest {
+    player.setSkipSilenceEnabled(true)
+
+    assertTrue(internalPlayer.skipSilenceEnabled)
+    assertEquals(
+      TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_DISABLED,
+      internalPlayer.trackSelectionParameters.audioOffloadPreferences.audioOffloadMode,
+    )
+
+    player.setSkipSilenceEnabled(false)
+
+    assertFalse(internalPlayer.skipSilenceEnabled)
+    assertEquals(
+      TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED,
+      internalPlayer.trackSelectionParameters.audioOffloadPreferences.audioOffloadMode,
+    )
+  }
 
   @Test
   fun `seekToNext does not clip`() = scope.runTest {

--- a/core/playback/src/test/kotlin/voice/core/playback/session/MediaItemProviderTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/session/MediaItemProviderTest.kt
@@ -1,0 +1,39 @@
+package voice.core.playback.session
+
+import androidx.media3.common.C
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import org.junit.runner.RunWith
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.MarkData
+import voice.core.playback.session.search.book
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class MediaItemProviderTest {
+
+  private val provider = MediaItemProvider(mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+
+  @Test
+  fun `only final mark uses end of source`() {
+    val chapter = Chapter(
+      id = ChapterId("chapter"),
+      name = "Chapter",
+      duration = 20_000,
+      fileLastModified = Instant.EPOCH,
+      markData = listOf(
+        MarkData(startMs = 0, name = "Intro"),
+        MarkData(startMs = 12_000, name = "Chapter 1"),
+      ),
+      fileSize = 0,
+    )
+
+    val mediaItems = provider.playbackItems(book(listOf(chapter)))
+
+    assertEquals(chapter.chapterMarks.first().endMs, mediaItems.first().clippingConfiguration.endPositionMs)
+    assertEquals(C.TIME_END_OF_SOURCE, mediaItems.last().clippingConfiguration.endPositionMs)
+  }
+}


### PR DESCRIPTION
## Summary

Fix playback continuing past the audible end of headerless VBR MP3 files and make silence skipping effective.

Some VBR MP3 files do not contain a Xing or VBRI seek table. Media3 can treat these files as constant-bitrate audio, resulting in an incorrect duration and a long silent tail.

## Changes

- Enable indexed seeking for headerless VBR MP3 files.
- Allow the final chapter mark to play to the actual end of the source.
- Persist corrected durations when Media3 updates the timeline.
- Route silence skipping through the audio processor chain.
- Disable audio offload while silence skipping is enabled.
- Add focused tests for seeking, duration updates, clipping, and silence skipping.

## Testing

- `./gradlew :core:playback:testDebugUnitTest`