### PR TITLE
Enable parallel gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,11 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -XX:MaxMeta
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.parallel=true
 org.gradle.priority=low
+org.gradle.tooling.parallel=true
 org.gradle.vfs.watch=true
 
 org.gradle.unsafe.isolated-projects=true
 ksp.project.isolation.enabled=true
 
 voice.warningsAsErrors=true
+


### PR DESCRIPTION
# 🎯 Motivation & Background

Parallel tooling sync enables a faster IDE.

[See more](https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism)
