### PR TITLE
Cache the image uri file provider calls

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/session/ImageFileProvider.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/ImageFileProvider.kt
@@ -4,13 +4,21 @@ import android.app.Application
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.FileProvider
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 @Inject
+@SingleIn(AppScope::class)
 class ImageFileProvider(private val application: Application) {
 
-  internal fun uri(file: File): Uri {
+  private val uris = ConcurrentHashMap<File, Uri>()
+
+  internal fun uri(file: File): Uri = uris.computeIfAbsent(file) { grantedUri(file) }
+
+  private fun grantedUri(file: File): Uri {
     return FileProvider
       .getUriForFile(
         application,


### PR DESCRIPTION
# 🎯 Why are we making this change?

With the recent change of splitting media items (#3634), this leads to an overhead where a single cover was created multiple times by the provider.
This caches this and reduces the performance overhead.
